### PR TITLE
Fix pip dependency resolution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ hypothesis[numpy]
 numpy<2
 pandas
 pygmt
-pygmt_helper @ git+https://github.com/ucgmsim/pygmt_helper.git
+pygmt_helper @ git+https://github.com/ucgmsim/pygmt_helper
 pytest
 pytest-cov
 pyvista

--- a/tests/test_bounding_box.py
+++ b/tests/test_bounding_box.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import numpy as np
 import shapely
-from hypothesis import HealthCheck, assume, given, seed, settings
+from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 
 from qcore import coordinates


### PR DESCRIPTION
Unfortunately, pip really requires the git urls to be **exactly** the same to resolve dependencies correctly (even if the URLs resolve to the same commit hash). This fixes the velocity_modelling requirements list to match the source_modelling one.