### PR TITLE
Add modules for reading and writing 1d velocity models

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 diffimg
 hypothesis[numpy]
 numpy<2
-pandas
+pandas[parquet]
 pygmt
 pygmt_helper @ git+https://github.com/ucgmsim/pygmt_helper
 pytest

--- a/tests/test_velocity_model_1d.py
+++ b/tests/test_velocity_model_1d.py
@@ -1,0 +1,123 @@
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from velocity_modelling import velocity_model_1d
+
+
+@pytest.fixture
+def sample_velocity_data() -> pd.DataFrame:
+    """Create a sample velocity model DataFrame for testing."""
+    return pd.DataFrame({
+        'width': [100.0, 200.0, 300.0],
+        'Vp': [2000.0, 3000.0, 4000.0],
+        'Vs': [1200.0, 1800.0, 2400.0],
+        'rho': [2.2, 2.4, 2.6],
+        'Qp': [100.0, 150.0, 200.0],
+        'Qs': [50.0, 75.0, 100.0]
+    })
+
+@pytest.fixture
+def temp_parquet_file(tmp_path: Path) -> Path:
+    """Create a temporary parquet file for testing."""
+    return tmp_path / 'velocity_model.parquet'
+
+@pytest.fixture
+def temp_text_file(tmp_path: Path) -> Path:
+    """Create a temporary text file for testing."""
+    return tmp_path / 'velocity_model.txt'
+
+def test_read_velocity_model_1d(sample_velocity_data: pd.DataFrame, temp_parquet_file: Path):
+    """Test reading velocity model from parquet and depth calculations."""
+    sample_velocity_data.to_parquet(temp_parquet_file)
+    result = velocity_model_1d.read_velocity_model_1d(temp_parquet_file)
+    
+    assert set(result.columns.tolist()) == {'width', 'Vp', 'Vs', 'rho', 'Qp', 'Qs', 'top_depth', 'bottom_depth'}
+    
+    expected_top_depths = [0.0, 100.0, 300.0]
+    expected_bottom_depths = [100.0, 300.0, 600.0]
+    
+    np.testing.assert_array_almost_equal(result['top_depth'], expected_top_depths)
+    np.testing.assert_array_almost_equal(result['bottom_depth'], expected_bottom_depths)
+
+def test_read_velocity_model_1d_missing_columns(temp_parquet_file: Path):
+    """Test reading velocity model with missing required columns."""
+    invalid_data = pd.DataFrame({
+        'width': [100.0],
+        'Vp': [2000.0]
+    })
+    invalid_data.to_parquet(temp_parquet_file)
+    
+    with pytest.raises(ValueError, match='Missing required columns'):
+        velocity_model_1d.read_velocity_model_1d(temp_parquet_file)
+
+def test_read_velocity_model_1d_negative_values(temp_parquet_file: Path):
+    """Test reading velocity model with negative values."""
+    invalid_data = pd.DataFrame({
+        'width': [100.0],
+        'Vp': [-2000.0],
+        'Vs': [1200.0],
+        'rho': [2.2],
+        'Qp': [100.0],
+        'Qs': [50.0]
+    })
+    invalid_data.to_parquet(temp_parquet_file)
+    
+    with pytest.raises(ValueError, match='may not contain negative numbers'):
+        velocity_model_1d.read_velocity_model_1d(temp_parquet_file)
+
+def test_read_velocity_model_1d_plain_text(sample_velocity_data: pd.DataFrame, temp_text_file: Path):
+    """Test reading velocity model from plain text format."""
+    velocity_model_1d.write_velocity_model_1d_plain_text(sample_velocity_data, temp_text_file)
+    result = velocity_model_1d.read_velocity_model_1d_plain_text(temp_text_file)
+    
+    assert set(result.columns.tolist()) == {'width', 'Vp', 'Vs', 'rho', 'Qp', 'Qs', 'top_depth', 'bottom_depth'}
+    pd.testing.assert_frame_equal(
+        result[['width', 'Vp', 'Vs', 'rho', 'Qp', 'Qs']], 
+        sample_velocity_data,
+        check_dtype=True
+    )
+
+def test_read_velocity_model_1d_plain_text_invalid_header(temp_text_file: Path):
+    """Test reading plain text with invalid header."""
+    with open(temp_text_file, 'w') as f:
+        f.write('invalid\n')
+        f.write('100 2000 1200 2.2 100 50\n')
+    
+    with pytest.raises(ValueError, match='Invalid or missing layer count'):
+        velocity_model_1d.read_velocity_model_1d_plain_text(temp_text_file)
+
+def test_read_velocity_model_1d_plain_text_layer_mismatch(temp_text_file: Path):
+    """Test reading plain text with layer count mismatch."""
+    with open(temp_text_file, 'w') as f:
+        f.write('2\n')  # Claim 2 layers but write 1
+        f.write('100 2000 1200 2.2 100 50\n')
+    
+    with pytest.raises(ValueError, match='does not match the header'):
+        velocity_model_1d.read_velocity_model_1d_plain_text(temp_text_file)
+
+def test_read_velocity_model_1d_plain_text_empty_data(temp_text_file: Path):
+    """Test reading plain text with no data after header."""
+    with open(temp_text_file, 'w') as f:
+        f.write('1\n')
+    
+    with pytest.raises(ValueError, match='Number of velocity model layers does not match the header.'):
+        velocity_model_1d.read_velocity_model_1d_plain_text(temp_text_file)
+
+def test_write_velocity_model_1d_plain_text(sample_velocity_data: pd.DataFrame, temp_text_file: Path):
+    """Test writing velocity model to plain text format."""
+    velocity_model_1d.write_velocity_model_1d_plain_text(sample_velocity_data, temp_text_file)
+    
+    with open(temp_text_file, 'r') as f:
+        lines = f.readlines()
+    
+    assert int(lines[0].strip()) == len(sample_velocity_data)
+    
+    for i, line in enumerate(lines[1:]):
+        values = [float(x) for x in line.strip().split()]
+        np.testing.assert_array_almost_equal(
+            values,
+            sample_velocity_data.iloc[i][['width', 'Vp', 'Vs', 'rho', 'Qp', 'Qs']].values
+        )

--- a/velocity_modelling/velocity_model_1d.py
+++ b/velocity_modelling/velocity_model_1d.py
@@ -1,0 +1,169 @@
+"""Utilities for reading and writing 1-D velocity profiles in different formats."""
+
+from pathlib import Path
+import pandas as pd
+import numpy as np
+
+def read_velocity_model_1d(velocity_model_path: Path) -> pd.DataFrame:
+    """Read a 1D velocity model from a Parquet file and compute depth boundaries.
+    
+    Parameters
+    ----------
+    velocity_model_path : Path
+        Path to the Parquet file containing the velocity model data.
+        Expected to contain columns for 'width' and velocity parameters.
+    
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame containing the velocity model with additional columns:
+        - top_depth : float
+            Depth to the top of each layer, computed from cumulative widths
+        - bottom_depth : float
+            Depth to the bottom of each layer
+        - width : float
+            Layer width/thickness
+        - Vp : float
+            P-wave velocity
+        - Vs : float
+            S-wave velocity
+        - rho : float
+            Density
+        - Qp : float
+            P-wave quality factor
+        - Qs : float
+            S-wave quality factor
+            
+    Raises
+    ------
+    ValueError
+        If any values in the velocity model are negative
+        If required columns are missing
+    """
+    velocity_model_1d = pd.read_parquet(velocity_model_path)
+    
+    # Check for required columns
+    required_columns = {'width', 'Vp', 'Vs', 'rho', 'Qp', 'Qs'}
+    missing_columns = required_columns - set(velocity_model_1d.columns.tolist())
+    if missing_columns:
+        raise ValueError(f'Missing required columns: {", ".join(missing_columns)}')
+    
+    # Check for negative values
+    if np.any(velocity_model_1d[list(required_columns)] < 0):
+        raise ValueError('Velocity model may not contain negative numbers.')
+    
+    velocity_model_1d['top_depth'] = velocity_model_1d['width'].cumsum() - velocity_model_1d['width']
+    velocity_model_1d['bottom_depth'] = velocity_model_1d['width'] + velocity_model_1d['top_depth']
+    return velocity_model_1d
+
+def read_velocity_model_1d_plain_text(velocity_model_path: Path) -> pd.DataFrame:
+    """Read a 1D velocity model from a plain text file and compute depth boundaries.
+    
+    Parameters
+    ----------
+    velocity_model_path : Path
+        Path to the text file containing the velocity model data.
+        File format must be:
+        - First line: number of layers (integer)
+        - Following lines: space-separated values for width, Vp, Vs, rho, Qp, Qs
+    
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame containing the velocity model with columns:
+        - top_depth : float
+            Depth to the top of each layer, computed from cumulative widths
+        - bottom_depth : float
+            Depth to the bottom of each layer
+        - width : float
+            Layer width/thickness
+        - Vp : float
+            P-wave velocity
+        - Vs : float
+            S-wave velocity
+        - rho : float
+            Density
+        - Qp : float
+            P-wave quality factor
+        - Qs : float
+            S-wave quality factor
+    
+    Raises
+    ------
+    ValueError
+        If the number of layers in the file doesn't match the header count
+        If any values in the velocity model are negative
+        If the header value is not a positive integer
+    
+    Notes
+    -----
+    The file format is compatible with the genslip program and related tools.
+    Layer depths are computed by accumulating the width values, where each layer's
+    top depth is the sum of all previous layer widths.
+    """
+    with open(velocity_model_path, 'r') as velocity_model:
+        # Validate header
+        try:
+            num_layers = int(next(velocity_model))
+            if num_layers <= 0:
+                raise ValueError('Number of layers must be positive.')
+        except (ValueError, StopIteration) as e:
+            raise ValueError('Invalid or missing layer count in header.') from e
+            
+        # Read data
+        try:
+            velocity_model_df = pd.read_csv(
+                velocity_model, 
+                header=None, 
+                delimiter=r'\s+',
+                names=['width', 'Vp', 'Vs', 'rho', 'Qp', 'Qs']
+            )
+        except pd.errors.ParserError:
+            raise ValueError('Invalid data format. Expected 6 space-separated numeric values per line.')
+
+    if len(velocity_model_df) != num_layers:
+        raise ValueError('Number of velocity model layers does not match the header.')
+
+    if np.any(velocity_model_df < 0):
+        raise ValueError('Velocity model may not contain negative numbers.')
+    
+    velocity_model_df['top_depth'] = velocity_model_df['width'].cumsum() - velocity_model_df['width']
+    velocity_model_df['bottom_depth'] = velocity_model_df['width'] + velocity_model_df['top_depth']
+    return velocity_model_df
+
+def write_velocity_model_1d_plain_text(velocity_model: pd.DataFrame, output_path: Path) -> None:
+    """Write a 1D velocity model to a plain text file in a specific format.
+    
+    Parameters
+    ----------
+    velocity_model : pd.DataFrame
+        DataFrame containing the velocity model data.
+        Must contain the following columns:
+        - width : float
+            Layer width/thickness
+        - Vp : float
+            P-wave velocity
+        - Vs : float
+            S-wave velocity
+        - rho : float
+            Density
+        - Qp : float
+            P-wave quality factor
+        - Qs : float
+            S-wave quality factor
+    
+    output_path : Path
+        Path where the output file will be written.
+        
+    Raises
+    ------
+    KeyError
+        If any required columns are missing from the input DataFrame
+    ValueError
+        If any values in the velocity model are negative
+    """
+    required_columns = ['width', 'Vp', 'Vs', 'rho', 'Qp', 'Qs']
+    
+    with open(output_path, 'w') as output_file:
+        output_file.write(f'{len(velocity_model)}\n')
+        velocity_model[required_columns].to_csv(output_file, sep=' ', header=False, index=False)

--- a/velocity_modelling/velocity_model_1d.py
+++ b/velocity_modelling/velocity_model_1d.py
@@ -1,8 +1,10 @@
 """Utilities for reading and writing 1-D velocity profiles in different formats."""
 
 from pathlib import Path
-import pandas as pd
+
 import numpy as np
+import pandas as pd
+
 
 def read_velocity_model_1d(velocity_model_path: Path) -> pd.DataFrame:
     """Read a 1D velocity model from a Parquet file and compute depth boundaries.


### PR DESCRIPTION
This PR introduces functions to read and write 1-D velocity models in two formats: parquet (preferred) and the traditional text files. The purpose of this PR is to migrate away from the text files profiles that look like the following:
<details>
<pre>
34
  0.0500    1.8000    0.3800    1.8100   38.00   19.00
  0.0500    1.8000    0.4800    1.8100   48.00   24.00
  0.0500    1.8000    0.5800    1.8100   58.00   29.00
  0.0500    1.8000    0.6800    1.8100   68.00   34.00
  0.1000    1.8000    0.7500    1.8100   75.00   37.50
  0.1000    1.8000    0.8300    1.8100   83.00   41.50
  0.2000    1.9000    0.9000    1.8600   90.00   45.00
  0.2000    2.0300    1.0000    1.9200  100.00   50.00
  0.2000    2.1400    1.0500    1.9700  105.00   52.50
  0.2000    2.2000    1.1000    1.9900  110.00   55.00
  0.2000    2.4000    1.1500    2.0600  115.00   57.50
  0.2000    2.7000    1.2000    2.1500  120.00   60.00
  0.2000    3.0000    1.4300    2.2200  143.00   71.50
  0.2000    3.2700    1.6400    2.2800  164.00   82.00
  0.2000    3.5300    1.8600    2.3200  186.00   93.00
  0.2000    3.8000    2.0700    2.3600  207.00  103.50
  0.2000    4.0700    2.2800    2.4000  228.00  114.00
  0.2000    4.3300    2.4900    2.4400  249.00  124.50
  0.2000    4.6000    2.7000    2.4800  270.00  135.00
  0.2000    4.7100    2.7700    2.4900  277.00  138.50
  0.2000    4.8200    2.8400    2.5100  284.00  142.00
  0.2000    4.9300    2.9100    2.5200  291.00  145.50
  0.2000    5.0400    2.9800    2.5400  298.00  149.00
  0.2000    5.1500    3.0500    2.5600  305.00  152.50
  0.2000    5.2600    3.1200    2.5800  312.00  156.00
  0.2000    5.3700    3.1900    2.6000  319.00  159.50
  0.2000    5.4800    3.2600    2.6100  326.00  163.00
  0.2000    5.5900    3.3300    2.6300  333.00  166.50
  0.2000    5.7000    3.4000    2.6600  340.00  170.00
  3.0000    6.0000    3.6000    2.7200  360.00  180.00
  4.0000    6.0000    3.6000    2.7200  360.00  180.00
 15.0000    6.5000    3.7000    2.8300  370.00  185.00
 12.0000    7.5000    4.3000    3.1200  430.00  215.00
999.0000    8.1000    4.6000    3.3300  460.00  230.00
</pre>
</details>
to standardising on parquet files that are converted as-needed into text files for genslip and high frequency simulation. Why bother doing this at all?

1. Standardising on data formats that are familiar to other researchers. All they need to read the parquet files is a copy of pandas.
2. Data validation and representation. Parquet files store floating point numbers with better validation and representation logic.
3. Documentation. Do you know what the 5th column in the 1d velocity model means? Neither, until I dug through the genslip source code and looked it up! The columns in the parquet file come annotated with column names so you can understand what each column means.

To manipulate text files we have `velocity_model_1d.read_velocity_model_1d_plain_text` and `velocity_model_1d.write_velocity_model_1d_plain_text`. To read and write the parquet files, use `velocity_model_1d.write_velocity_model` and `velocity_model_1d.read_velocity_model`.
