### PR TITLE
Use numpy version 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 diffimg
 hypothesis[numpy]
-numpy<2
+numpy
 pandas[parquet]
 pygmt
 pygmt_helper @ git+https://github.com/ucgmsim/pygmt_helper.git


### PR DESCRIPTION
Similar to other numpy PRs. We require `numpy<2` but there is no longer any good reason for this.
