### PR TITLE
Change mountpath for jenkins nzvm builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
             // as the user with uid = 0. This user is, by default, the
             // root user. So it is effectively saying run the commands
             // as root.
-            args "-u 0 -v /home/jenkins/Data:/nzvm/Data -v /home/jenkins/benchmarks:/nzvm/benchmarks -v /home/jenkins/global:/nzvm/global"
+            args "-u 0 -v /mnt/mantle_data/jenkins/nzvm/Data:/nzvm/Data -v /mnt/mantle_data/jenkins/nzvm/benchmarks:/nzvm/benchmarks -v /mnt/mantle_data/jenkins/nzvm/global:/nzvm/global"
         }
 
     }


### PR DESCRIPTION
Resolves a no space on mantle home because the data folder is too big by moving it to mantle.