### PR TITLE
Correct Wiki EXTENT_LATLON_SPACING units to km (from degrees)

### DIFF
--- a/wiki/Generating-Velocity-Model.md
+++ b/wiki/Generating-Velocity-Model.md
@@ -67,7 +67,7 @@ OUTPUT_DIR=/tmp
 - **EXTENT_ZMAX**: Maximum depth of the model grid (in kilometers).
 - **EXTENT_ZMIN**: Minimum depth of the model grid (in kilometers).
 - **EXTENT_Z_SPACING**: Spacing between grid points in the Z direction (in kilometers).
-- **EXTENT_LATLON_SPACING**: Spacing between grid points in the latitude and longitude directions (in degrees).
+- **EXTENT_LATLON_SPACING**: Spacing between grid points in the latitude and longitude directions (in km).
 - **MIN_VS**: Minimum shear wave velocity (in meter per second).
 - **TOPO_TYPE**: Type of topography to use. Possible values are `BULLDOZED`, `SQUASHED`, `SQUASHED_TAPERED` and `TRUE`. 
 - **OUTPUT_DIR**: Directory where the generated velocity model files will be saved.


### PR DESCRIPTION
A small correction to the units of EXTENT_LATLON_SPACING in the Wiki. It should be in km, but it was written as being in degrees.