### PR TITLE
HDF5 fix and extract_cross_section script

### DIFF
--- a/velocity_modelling/scripts/extract_cross_section.py
+++ b/velocity_modelling/scripts/extract_cross_section.py
@@ -1,0 +1,364 @@
+"""
+Extract cross-section from a velocity model and plot it.
+This script reads a velocity model from an HDF5 file and generates a cross-section plot
+based on specified coordinates or grid indices. It also allows for saving the cross-section data
+to a CSV file.
+
+Usage:
+    python extract_cross_section.py <h5file> [options]
+    --lat1 <lat1> --lon1 <lon1> --lat2 <lat2> --lon2 <lon2>
+    --x1 <x1> --y1 <y1> --x2 <x2> --y2 <y2>
+    --property <property_name> --xaxis <xaxis> --n_points <n_points>
+    --vmin <vmin> --vmax <vmax> --max_depth <max_depth>
+    --cmap <cmap> --png <output_png> --csv <csv_output>
+
+    --help
+    -h, --help  Show this help message and exit.
+    <h5file>       Path to the HDF5 file containing the velocity model.
+    --lat1 <lat1>   Latitude of the first point of the cross-section.
+    --lon1 <lon1>   Longitude of the first point of the cross-section.
+    --lat2 <lat2>   Latitude of the second point of the cross-section.
+    --lon2 <lon2>   Longitude of the second point of the cross-section.
+    --x1 <x1>       Grid index of the first point of the cross-section.
+    --y1 <y1>       Grid index of the first point of the cross-section.
+    --x2 <x2>       Grid index of the second point of the cross-section.
+    --y2 <y2>       Grid index of the second point of the cross-section.
+    --property <property_name>
+                    Property to extract from the velocity model (default: "vp").
+    --xaxis <xaxis> Choose x-axis for cross-section ("auto", "lat", "lon").
+
+    --n_points <n_points>
+                    Number of points in the cross-section (default: 350).
+    --vmin <vmin>   Minimum value for color scaling (default: None).
+    --vmax <vmax>   Maximum value for color scaling (default: None).
+    --max_depth <max_depth>
+                    Maximum depth to include in the cross-section (default: None).
+    --cmap <cmap>   Colormap for the cross-section (default: "jet").
+    --png <output_png>
+                    Prefix to save the output PNG image (default: None). If specified,
+                    two images will be created: <output_png>_plot.png and
+                    <output_png>_map.png.
+    --csv <csv_output>
+                    Path to save the cross-section data as CSV (default: None).
+    --help         Show this help message and exit.
+
+
+"""
+
+#!/usr/bin/env python3
+from pathlib import Path
+from typing import Annotated, Optional
+
+import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+import h5py
+import matplotlib.pyplot as plt
+import numpy as np
+import typer
+from cartopy.mpl.gridliner import LATITUDE_FORMATTER, LONGITUDE_FORMATTER
+
+from qcore import cli
+
+app = typer.Typer(pretty_exceptions_enable=False)
+
+
+@cli.from_docstring(app)
+def extract_cross_section(
+    h5file: Annotated[Path, typer.Argument(exists=True, dir_okay=False)],
+    lat1: Annotated[Optional[float], typer.Option()] = None,
+    lon1: Annotated[Optional[float], typer.Option()] = None,
+    lat2: Annotated[Optional[float], typer.Option()] = None,
+    lon2: Annotated[Optional[float], typer.Option()] = None,
+    x1: Annotated[Optional[int], typer.Option()] = None,
+    y1: Annotated[Optional[int], typer.Option()] = None,
+    x2: Annotated[Optional[int], typer.Option()] = None,
+    y2: Annotated[Optional[int], typer.Option()] = None,
+    property_name: Annotated[str, typer.Option()] = "vp",
+    xaxis: Annotated[str, typer.Option()] = "auto",
+    n_points: Annotated[int, typer.Option()] = 350,
+    vmin: Annotated[Optional[float], typer.Option()] = None,
+    vmax: Annotated[Optional[float], typer.Option()] = None,
+    max_depth: Annotated[Optional[float], typer.Option()] = None,
+    cmap: Annotated[str, typer.Option()] = "jet",
+    png: Annotated[Optional[Path], typer.Option()] = None,
+    csv: Annotated[Optional[Path], typer.Option()] = None,
+):
+    """
+    Plot a cross-section of velocity model.
+
+    Parameters
+    ----------
+    h5file : Path
+        Path to the HDF5 file containing the velocity model.
+    lat1, lon1 : float, optional
+        Latitude and longitude of the first point of the cross-section.
+    lat2, lon2 : float, optional
+        Latitude and longitude of the second point of the cross-section.
+    x1, y1 : int, optional
+        Grid indices of the first point of the cross-section.
+    x2, y2 : int, optional
+        Grid indices of the second point of the cross-section.
+    property_name : str, optional
+        Property to extract (default: "vp").
+    xaxis : str, optional
+        X-axis type for the cross-section ("auto", "lat", "lon").
+    n_points : int, optional
+        Number of points in the cross-section (default: 350).
+    vmin, vmax : float, optional
+        Minimum and maximum values for color scaling.
+    max_depth : float, optional
+        Maximum depth to include in the cross-section.
+    cmap : str, optional
+        Colormap for the cross-section (default: "jet").
+    png : Path, optional
+        Prefix to save the output PNG image, if specified, xxx_plot.png and xxx_map.png will be created.
+    csv : Path, optional
+        Path to save the cross-section data as CSV.
+    """
+
+    # Raise ValueError if both grid indices and coordinates are specified
+    if (x1 is not None and lon1 is not None) or (y1 is not None and lat1 is not None):
+        raise ValueError(
+            "Both grid indices (x1, y1) and coordinates (lat1, lon1) are specified. "
+            "Please specify only one of them."
+        )
+
+    print(f"Creating improved cross-section from {h5file}")
+    with h5py.File(h5file, "r") as f:
+        lat = f["/mesh/lat"][()]
+        lon = f["/mesh/lon"][()]
+        z = f["/mesh/z"][()]
+        data = f[f"/properties/{property_name}"][()]
+        config = f.get("/config", {})
+
+        extent_z_spacing = config.attrs.get("h_depth")
+        if isinstance(extent_z_spacing, str):
+            extent_z_spacing = float(extent_z_spacing)
+
+        origin_lat = float(config.attrs.get("origin_lat", 0.0))
+        origin_lon = float(config.attrs.get("origin_lon", 0.0))
+        origin_rot = float(config.attrs.get("origin_rot", 0.0))
+
+        z_km = z * extent_z_spacing
+
+        if z[0] > z[-1]:
+            z = z[::-1]
+            z_km = z_km[::-1]
+            data = data[::-1, :, :]
+
+        if max_depth is not None:
+            z_mask = z_km <= max_depth
+            z = z[z_mask]
+            z_km = z_km[z_mask]
+            data = data[z_mask, :, :]
+
+        # Derive coordinates if only lat/lon are given
+        if lat1 is not None and lon1 is not None:
+            (
+                lat1_val,
+                lon1_val,
+            ) = lat1, lon1
+            lat2_val = (
+                lat2 if lat2 is not None else lat1
+            )  # if undefined, use lat1. Horizontal cross-section
+            lon2_val = (
+                lon2 if lon2 is not None else lon1
+            )  # if undefined, use lon1. Vertical cross-section
+            dist1 = (lat - lat1_val) ** 2 + (lon - lon1_val) ** 2
+            dist2 = (lat - lat2_val) ** 2 + (lon - lon2_val) ** 2
+            x1, y1 = np.unravel_index(
+                np.argmin(dist1), dist1.shape
+            )  # find the closest point from (lat1,lon1)
+            x2, y2 = np.unravel_index(
+                np.argmin(dist2), dist2.shape
+            )  # find the closest point from (lat2,lon2)
+        elif x1 is not None and y1 is not None:
+            x1 = int(x1)
+            y1 = int(y1)
+            x2 = (
+                int(x2) if x2 is not None else x1
+            )  # if undefined, use x1. Horizontal cross-section
+            y2 = (
+                int(y2) if y2 is not None else y1
+            )  # if undefined, use y1. Vertical cross-section
+            lat1_val = lat[x1, y1]
+            lon1_val = lon[x1, y1]
+            lat2_val = lat[x2, y2]
+            lon2_val = lon[x2, y2]
+        else:
+            raise ValueError(
+                "You must specify either --x1, --y1[, --x2, --y2] or --lat1, --lon1, --lat2, --lon2"
+            )
+
+        if lat1_val == lat2_val:
+            # Horizontal cross-section (constant latitude)
+            lat_pts = np.full(n_points, lat1_val)
+            lon_pts = np.linspace(lon1_val, lon2_val, n_points)
+        elif lon1_val == lon2_val:
+            # Vertical cross-section (constant longitude)
+            lat_pts = np.linspace(lat1_val, lat2_val, n_points)
+            lon_pts = np.full(n_points, lon1_val)
+        else:
+            # Diagonal cross-section
+            lat_pts = np.linspace(lat1_val, lat2_val, n_points)
+            lon_pts = np.linspace(lon1_val, lon2_val, n_points)
+
+        dx = lon2_val - lon1_val
+        dy = lat2_val - lat1_val
+        # Calculate the angle of the cross-section
+        angle_deg = np.degrees(np.arctan2(dy, dx)) % 180
+
+        # Determine the x-axis based on the angle
+        if xaxis == "auto":
+            xaxis = "lat" if angle_deg > 45 else "lon"
+
+        if xaxis == "lat" and abs(dy) < 1e-6:
+            raise ValueError(
+                "Latitude cross-section requested but latitude range is zero."
+            )
+        if xaxis == "lon" and abs(dx) < 1e-6:
+            raise ValueError(
+                "Longitude cross-section requested but longitude range is zero."
+            )
+
+        cross_section = np.zeros((len(z), n_points))
+        idx_map = []
+
+        # Loop through each point along the cross-section path
+        for i in range(n_points):
+            # Calculate the distance from the current point to all grid points
+            dist = (lat - lat_pts[i]) ** 2 + (lon - lon_pts[i]) ** 2
+            # Find the grid point closest to the current point
+            x_idx, y_idx = np.unravel_index(np.argmin(dist), dist.shape)
+            # Extract the property values along the depth for the closest grid point
+            for j, zval in enumerate(z):
+                cross_section[j, i] = data[j, y_idx, x_idx]
+            # Store the grid indices for reference
+            idx_map.append((x_idx, y_idx))
+
+        if csv:
+            import pandas as pd
+
+            # Prepare data for DataFrame
+            data_rows = []
+            for i in range(n_points):
+                x_idx, y_idx = idx_map[i]
+                for j in range(len(z)):
+                    data_rows.append(
+                        {
+                            "z_km": round(z_km[j], 4),
+                            "lon": round(lon[x_idx, y_idx], 4),
+                            "lat": round(lat[x_idx, y_idx], 4),
+                            "value": round(cross_section[j, i], 4),
+                            "x": x_idx,
+                            "y": y_idx,
+                        }
+                    )
+
+            # Create DataFrame and save to CSV
+            df = pd.DataFrame(data_rows)
+            df.to_csv(csv, index=False)
+
+        # Instead of a combined figure, create two separate figures
+
+        # First figure - Map
+        fig_map = plt.figure(figsize=(8, 8))
+
+        projection = ccrs.PlateCarree()
+        ax_map = plt.axes(projection=projection)
+        ax_map.set_extent([lon.min(), lon.max(), lat.min(), lat.max()])
+
+        # Turn off axes completely to remove the frame
+        ax_map.axis("off")
+
+        # Add features with adjusted styling
+        ax_map.add_feature(cfeature.COASTLINE, linewidth=0.5, edgecolor="gray")
+        ax_map.add_feature(
+            cfeature.BORDERS, linestyle=":", linewidth=0.3, edgecolor="gray"
+        )
+        ax_map.add_feature(cfeature.LAND, edgecolor="none", facecolor="whitesmoke")
+        ax_map.add_feature(cfeature.OCEAN, edgecolor="none", facecolor="lightcyan")
+        ax_map.add_feature(
+            cfeature.LAKES, edgecolor="gray", linewidth=0.3, facecolor="lightcyan"
+        )
+        ax_map.add_feature(cfeature.RIVERS, linewidth=0.3, edgecolor="lightskyblue")
+
+        # Add gridlines separately after turning off the axis frame
+        gl = ax_map.gridlines(
+            draw_labels=True, linewidth=0.5, color="gray", alpha=0.5, linestyle=":"
+        )
+        gl.top_labels = False
+        gl.right_labels = False
+        gl.xformatter = LONGITUDE_FORMATTER
+        gl.yformatter = LATITUDE_FORMATTER
+
+        # Plot domain outline and cross-section path
+        domain_outline = [
+            (lon[0, 0], lat[0, 0]),
+            (lon[-1, 0], lat[-1, 0]),
+            (lon[-1, -1], lat[-1, -1]),
+            (lon[0, -1], lat[0, -1]),
+            (lon[0, 0], lat[0, 0]),
+        ]
+        lons, lats = zip(*domain_outline)
+
+        ax_map.plot(lons, lats, "r--", transform=projection, label="Domain")
+        ax_map.plot(lon_pts, lat_pts, "b-", transform=projection, label="Cross-section")
+        ax_map.plot(lon1_val, lat1_val, "bo", transform=projection)
+        ax_map.plot(lon2_val, lat2_val, "bo", transform=projection)
+        ax_map.text(lon1_val + 0.1, lat1_val, f"({lat1_val:.2f}, {lon1_val:.2f})")
+        ax_map.text(lon2_val + 0.1, lat2_val, f"({lat2_val:.2f}, {lon2_val:.2f})")
+        ax_map.plot(origin_lon, origin_lat, "ro", transform=projection, label="Origin")
+        ax_map.text(
+            origin_lon + 0.1,
+            origin_lat,
+            f"Rot: {origin_rot:.2f}°",
+            transform=projection,
+        )
+        ax_map.legend(fontsize=8)
+        ax_map.set_title("Velocity Model Domain with Cross-section Path", fontsize=12)
+
+        # Save map if png is specified
+        if png:
+            map_filename = f"{png}_map.png"
+            fig_map.savefig(map_filename, dpi=300, bbox_inches="tight")
+            print(f"Map saved to {map_filename}")
+
+        # Second figure - Cross-section
+        fig_section = plt.figure(figsize=(12, 6))
+        ax_section = plt.axes()
+
+        x_vals = lon_pts if xaxis == "lon" else lat_pts
+        xlabel = "Longitude" if xaxis == "lon" else "Latitude"
+        ax_section.set_xlabel(xlabel)
+        ax_section.set_ylabel("Depth (km)")
+        ax_section.set_ylim([z_km.max(), z_km.min()])
+        ax_section.tick_params(axis="x", direction="inout", top=True, which="both")
+        ax_section.tick_params(axis="y", direction="inout", right=True, which="both")
+        ax_section.minorticks_on()
+        ax_section.xaxis.set_ticks(np.linspace(x_vals.min(), x_vals.max(), 11))
+        ax_section.yaxis.set_ticks(np.linspace(z_km.min(), z_km.max(), 10))
+        pcm = ax_section.pcolormesh(
+            x_vals, z_km, cross_section, shading="auto", cmap=cmap, vmin=vmin, vmax=vmax
+        )
+        unit = "(g/cm³)" if property_name == "rho" else "(km/s)"
+        fig_section.colorbar(pcm, ax=ax_section, label=f"{property_name} {unit}")
+        ax_section.set_title(
+            f"{property_name} : cross-section along {xlabel}\n"
+            f"({lat1_val:.4f}, {lon1_val:.4f}) to ({lat2_val:.4f}, {lon2_val:.4f})\n"
+            f"Index: x=({x1},{x2}), y=({y1},{y2})",
+            fontsize=12,
+        )
+
+        # Save cross-section if png is specified
+        if png:
+            section_filename = f"{png}_plot.png"
+            fig_section.savefig(section_filename, dpi=300, bbox_inches="tight")
+            print(f"Cross-section saved to {section_filename}")
+
+        # Display both figures
+        plt.show()
+
+
+if __name__ == "__main__":
+    app()

--- a/velocity_modelling/write/hdf5.py
+++ b/velocity_modelling/write/hdf5.py
@@ -33,35 +33,17 @@ def create_xdmf_file(hdf5_file: Path, vm_params: dict, logger: logging.Logger) -
         Logger for reporting progress and errors.
     """
     xdmf_file = hdf5_file.with_suffix(".xdmf")
+    nx = vm_params.get("nx")
+    ny = vm_params.get("ny")
+    nz = vm_params.get("nz")
+    if not all([nx, ny, nz]):
+        logger.log(
+            logging.ERROR,
+            "Missing 'nx' 'ny' or 'nz' key in vm_params. Ensure the velocity model parameters are correctly set.",
+        )
+        raise KeyError("Missing nx, ny, or nz in vm_params")
 
-    try:
-        nx = vm_params.get("nx")
-    except KeyError:
-        logger.log(
-            logging.ERROR,
-            "Missing 'nx' key in vm_params. Ensure the velocity model parameters are correctly set.",
-        )
-        raise KeyError("Missing 'nx' key in vm_params.")
-    try:
-        ny = vm_params.get("ny")
-    except KeyError:
-        logger.log(
-            logging.ERROR,
-            "Missing 'ny' key in vm_params. Ensure the velocity model parameters are correctly set.",
-        )
-        raise KeyError("Missing 'ny' key in vm_params.")
-    try:
-        nz = vm_params.get("nz")
-    except KeyError:
-        logger.log(
-            logging.ERROR,
-            "Missing 'nz' key in vm_params. Ensure the velocity model parameters are correctly set.",
-        )
-        raise KeyError("Missing 'nz' key in vm_params.")
-
-    # Get the relative path to the HDF5 file from the XDMF file
     hdf5_relative = hdf5_file.name
-
     xdmf_content = f"""<?xml version="1.0" ?>
 <!DOCTYPE Xdmf SYSTEM "Xdmf.dtd" []>
 <Xdmf Version="3.0">
@@ -100,7 +82,7 @@ def create_xdmf_file(hdf5_file: Path, vm_params: dict, logger: logging.Logger) -
         </DataItem>
       </Attribute>
     </Grid>
-  </Domain>c
+  </Domain>
 </Xdmf>
 """
 
@@ -110,7 +92,7 @@ def create_xdmf_file(hdf5_file: Path, vm_params: dict, logger: logging.Logger) -
         logger.log(logging.INFO, f"Created ParaView-compatible XDMF file: {xdmf_file}")
     except Exception as e:
         if isinstance(e, (SystemExit, KeyboardInterrupt)):
-            raise  # Re-raise critical exceptions
+            raise
         logger.log(logging.ERROR, f"Error creating XDMF file: {e}")
         raise RuntimeError(f"Failed to create XDMF file: {e}")
 
@@ -149,18 +131,18 @@ def write_global_qualities(
     OSError
         If the HDF5 file cannot be written due to permissions or disk issues.
     """
-    # Output filename - single file for all slices
-    hdf5_file = Path(out_dir) / "velocity_model.h5"
+    if logger is None:
+        logger = Logger("xdmf")
 
-    # Apply minimum VS constraint
-    min_vs = vm_params.get(
-        "min_vs", 0.0
-    )  # Get the minimum Vs value from the parameters
+    # Output filename - single file for all slices
+    hdf5_file = out_dir / "velocity_model.h5"
     vs_data = np.copy(partial_global_qualities.vs)
+    min_vs = vm_params.get("min_vs", 0.0)
     vs_data[vs_data < min_vs] = min_vs
 
-    # ny is the number of slices in the y direction, but what we are processing here is a single slice along y (=lat)
-    # axis, so we need to get the total number of slices from the vm_params
+    # ny is the number of slices in the y direction, but what we are processing here is a single slice
+    # along y (=lat if not-rotated) axis, so we need to get the total number of slices from the vm_params
+
     try:
         ny = vm_params["ny"]
     except KeyError:
@@ -170,131 +152,99 @@ def write_global_qualities(
         )
         raise KeyError("Missing 'ny' key in vm_params.")
 
+    nx, nz = partial_global_qualities.vp.shape
+
     # If first slice, create the file and initialize structure
     if lat_ind == 0:
         try:
             with h5py.File(hdf5_file, "w") as f:
-                logger.log(logging.DEBUG, f"Creating new HDF5 file: {hdf5_file}")
+                f.attrs.update(
+                    {
+                        "total_y_slices": ny,
+                        "format_version": "1.0",
+                        "creation_date": datetime.datetime.now().isoformat(),
+                    }
+                )
 
-                # Add basic metadata attributes
-                f.attrs["total_y_slices"] = ny
-                f.attrs["format_version"] = "1.0"
-                f.attrs["creation_date"] = datetime.datetime.now().isoformat()
+                config_group = f.create_group("config")
+                config_group.attrs.update(
+                    {
+                        k: (
+                            v.name
+                            if hasattr(v, "name")
+                            else v.value
+                            if hasattr(v, "value")
+                            else str(v)
+                        )
+                        for k, v in vm_params.items()
+                    }
+                )
+                config_group.attrs["config_string"] = "\n".join(
+                    f"{k.upper()}={v}" for k, v in vm_params.items()
+                )
 
-                # Add all velocity model parameters from nzcvm.cfg as root attributes
-                if vm_params:
-                    config_group = f.create_group("config")
-                    for key, value in vm_params.items():
-                        # Handle special case for enum types
-                        if hasattr(value, "name"):
-                            config_group.attrs[key] = value.name
-                        elif hasattr(value, "value"):
-                            config_group.attrs[key] = value.value
-                        else:
-                            try:
-                                config_group.attrs[key] = value
-                            except TypeError:
-                                # If attribute can't be stored directly, convert to string
-                                config_group.attrs[key] = str(value)
+                mesh_group = f.create_group("mesh")
+                mesh_group.create_dataset("x", data=np.arange(nx, dtype=np.float64))
+                mesh_group.create_dataset("y", data=np.arange(ny, dtype=np.float64))
+                mesh_group.create_dataset(
+                    "z", data=np.arange(nz, dtype=np.float64)
+                )  # depth 0 is the top, the higher z is the deeper
+                mesh_group.create_dataset("lat", shape=(nx, ny), dtype="f8")
+                mesh_group.create_dataset("lon", shape=(nx, ny), dtype="f8")
 
-                    # Add a string representation of the original config for reference
-                    config_lines = []
-                    for key, value in vm_params.items():
-                        if hasattr(value, "name"):
-                            config_lines.append(f"{key.upper()}={value.name}")
-                        else:
-                            config_lines.append(f"{key.upper()}={value}")
-                    config_str = "\n".join(config_lines)
-                    config_group.attrs["config_string"] = config_str
+                props = f.create_group("properties")
 
-                # Create groups for mesh and properties
-                f.create_group("mesh")
-                f.create_group("properties")
+                # Create datasets with shape (nz, ny, nx): Paraview demands this order
+                shape = (nz, ny, nx)
 
-                # Create resizable datasets for properties
-                props_group = f["properties"]
-                nx, nz = partial_global_qualities.vp.shape
-
-                # Log the dimensions for debugging
                 logger.log(
                     logging.DEBUG,
                     f"Creating datasets with shape (nz={nz}, ny={ny}, nx={nx})",
                 )
-
-                # Create datasets with shape (nz, ny, nx): Paraview demands this order
-                props_group.create_dataset(
-                    "vp", shape=(nz, ny, nx), dtype="f4", compression="gzip"
-                )
-                props_group.create_dataset(
-                    "vs", shape=(nz, ny, nx), dtype="f4", compression="gzip"
-                )
-                props_group.create_dataset(
-                    "rho", shape=(nz, ny, nx), dtype="f4", compression="gzip"
-                )
-                props_group.create_dataset(
-                    "inbasin", shape=(nz, ny, nx), dtype="i1", compression="gzip"
+                props.create_dataset("vp", shape=shape, dtype="f4", compression="gzip")
+                props.create_dataset("vs", shape=shape, dtype="f4", compression="gzip")
+                props.create_dataset("rho", shape=shape, dtype="f4", compression="gzip")
+                props.create_dataset(
+                    "inbasin", shape=shape, dtype="i1", compression="gzip"
                 )
 
                 # Add metadata
-                props_group["vp"].attrs["units"] = "km/s"
-                props_group["vs"].attrs["units"] = "km/s"
-                props_group["rho"].attrs["units"] = "g/cm^3"
-                props_group["vs"].attrs["min_value_enforced"] = min_vs
-
+                props["vp"].attrs["units"] = "km/s"
+                props["vs"].attrs.update(
+                    {"units": "km/s", "min_value_enforced": min_vs}
+                )
+                props["rho"].attrs["units"] = "g/cm^3"
         except OSError as e:
             logger.log(logging.ERROR, f"Failed to create HDF5 file {hdf5_file}: {e}")
             raise OSError(f"Failed to create HDF5 file {hdf5_file}: {str(e)}")
 
-    # Write this slice's data to the file
     try:
         with h5py.File(hdf5_file, "r+") as f:
-            # Write mesh data only once (when completing the model)
-            if lat_ind == ny - 1:
-                # Now that we have all slices, write the complete mesh data
-                mesh_group = f["mesh"]
-                mesh_group.create_dataset(
-                    "x", data=np.arange(partial_global_mesh.nx, dtype=np.float64)
-                )
-                mesh_group.create_dataset("y", data=np.arange(ny, dtype=np.float64))
-                # Depth is negative: -nz to 0
-                mesh_group.create_dataset(
-                    "z",
-                    data=np.arange(-1 * partial_global_mesh.nz, 0, dtype=np.float64),
-                )
-                mesh_group.create_dataset("lon", data=partial_global_mesh.lon)
-                mesh_group.create_dataset("lat", data=partial_global_mesh.lat)
-
-                # Mark file as complete
-                f.attrs["complete"] = True
+            f["mesh/lat"][:, lat_ind] = partial_global_mesh.lat
+            f["mesh/lon"][:, lat_ind] = partial_global_mesh.lon
 
             # Write property data for this slice to make this Paraview compatible
             # partial_global_qualities.vp is (nx, nz), need to transpose to (nz, nx) for (z, x)
             # Dataset is (nz, ny, nx), so [:, lat_ind, :] expects (nz, nx)
-            vp_slice = np.transpose(partial_global_qualities.vp)  # (nx, nz) -> (nz, nx)
-            vs_slice = np.transpose(vs_data)  # (nz, nx)
-            rho_slice = np.transpose(partial_global_qualities.rho)  # (nz, nx)
-            inbasin_slice = np.transpose(partial_global_qualities.inbasin)  # (nz, nx)
+            vp = partial_global_qualities.vp.T
+            vs = vs_data.T
+            rho = partial_global_qualities.rho.T
+            inbasin = partial_global_qualities.inbasin.T
 
-            # Verify shapes
-            expected_shape = (partial_global_mesh.nz, partial_global_mesh.nx)
-            if vp_slice.shape != expected_shape:
+            expected = (nz, nx)
+            if vp.shape != expected:
                 logger.log(
                     logging.ERROR,
-                    f"Shape mismatch: vp_slice has shape {vp_slice.shape}, expected {expected_shape}",
+                    f"Shape mismatch: vp has shape {vp.shape}, expected {expected}",
                 )
-                raise ValueError(
-                    f"Shape mismatch: vp_slice has shape {vp_slice.shape}, expected {expected_shape}"
-                )
+                raise ValueError(f"Shape mismatch: got {vp.shape}, expected {expected}")
 
-            f["properties/vp"][:, lat_ind, :] = vp_slice
-            f["properties/vs"][:, lat_ind, :] = vs_slice
-            f["properties/rho"][:, lat_ind, :] = rho_slice
-            f["properties/inbasin"][:, lat_ind, :] = inbasin_slice
+            f["properties/vp"][:, lat_ind, :] = vp
+            f["properties/vs"][:, lat_ind, :] = vs
+            f["properties/rho"][:, lat_ind, :] = rho
+            f["properties/inbasin"][:, lat_ind, :] = inbasin
 
-            # Update progress attribute
             f.attrs["last_slice_written"] = lat_ind
-
-        logger.log(logging.DEBUG, f"Written slice {lat_ind} to {hdf5_file}")
     except OSError as e:
         logger.log(logging.ERROR, f"Failed to update HDF5 file {hdf5_file}: {e}")
         raise OSError(f"Failed to update HDF5 file {hdf5_file}: {str(e)}")
@@ -306,6 +256,5 @@ def write_global_qualities(
 
     # After writing all slices, create the XDMF file
     if lat_ind == ny - 1:
-        # Now that we have written the entire model, create the XDMF file
         create_xdmf_file(hdf5_file, vm_params, logger)
         logger.log(logging.INFO, "HDF5 model complete with ParaView compatibility")


### PR DESCRIPTION
There was a strange mix-up, and #16 and #18 appear to have been merged into main (then closed - I didn't do it!), which is not true.
I'm opening a new PR, and will clean up the mess.

** HDF5 change **
3 major changes.

Refactor and tidy up
z values was incorrectly stored as negative integer: z is an index for "depth" where 0 is top and nz-1 is the bottom. Should be positive.
Before
                # Depth is negative: -nz to 0
                mesh_group.create_dataset(
                    "z",
                    data=np.arange(-1 * partial_global_mesh.nz, 0, dtype=np.float64),
                )
After

                mesh_group.create_dataset(
                    "z", data=np.arange(nz, dtype=np.float64)
                )  # depth 0 is the top, the higher z is the deeper
Unlike the EMOD3D output, HDF5 format can store lon and lat as well as the grid indices x,y,z.
lon and lat were originally incorrectly saved, copying the last slice's partial_global_mesh
Before

                mesh_group.create_dataset("lon", data=partial_global_mesh.lon)
                mesh_group.create_dataset("lat", data=partial_global_mesh.lat)
This is ok, if the domain is not rotated, but in reality, for the same x and y index, lon and lay will vary depending on the rotation, so lon and lat should be of size (nx,ny) and store the lon and lat obtained from the great circle projection code during the velocity model calcultion.

After


                mesh_group.create_dataset("lat", shape=(nx, ny), dtype="f8")
                mesh_group.create_dataset("lon", shape=(nx, ny), dtype="f8")
...
then for each slice, we store the lat and lon of partial_global_mesh

            f["mesh/lat"][:, lat_ind] = partial_global_mesh.lat
            f["mesh/lon"][:, lat_ind] = partial_global_mesh.lon

This ensures the correct integrity of data and enables correct rendering of a cross-section.


** Cross-section **

Usage:
```
python ~/velocity_modelling/velocity_modelling/scripts/extract_cross_section.py --lat1 -43.5 --lon1 171 --lat2 -44.5 --lon2 172  --vmax 9  ./velocity_model.h5 --png AA --xaxis lat
```
It assumes you have already produced a 3d velocity model in HDF5 format.

It produces a map and a plot and save them as XXX_map.png and XXX_plot.png 

![AA_map](https://github.com/user-attachments/assets/f5d953f5-e2b6-482d-9b32-7d3b3953b4fb)

![AA_plot](https://github.com/user-attachments/assets/12c0693a-1581-4e3e-ad2c-fb468f184768)

Tested against the legacy code (https://github.com/ucgmsim/Velocity-Model-Viz ) and the output is visually identical.

![image](https://github.com/user-attachments/assets/04125cf1-4331-4e86-b2db-986b3febb3ed)

