### PR TITLE
Explicitly instruct to have git lfs ready

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
                     // as the user with uid = 0. This user is, by default, the
                     // root user. So it is effectively saying run the commands
                     // as root.
-                    args "-u 0 -v /mnt/mantle_data/jenkins/nzvm/Data:/nzvm/Data -v /mnt/mantle_data/jenkins/nzvm/benchmarks:/nzvm/benchmarks -v /mnt/mantle_data/jenkins/nzvm/nzcvm_data:/nzvm/nzcvm_data"
+                    args "-u 0 -v /mnt/mantle_data/jenkins/nzvm/Data:/nzvm/Data -v /mnt/mantle_data/jenkins/nzvm/benchmarks:/nzvm/benchmarks -v /mnt/mantle_data/jenkins/nzvm/nzcvm_data:/nzvm/nzcvm_data -v /tmp/jenkins:/tmp"
                 }
             }
             stages {

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This separation allows independent version control of code and data while mainta
 
 - Python 3.11 or later
 - Git (for cloning the repository)
-- Git LFS (for large data files in the data repository. See [Git LFS) Installation](https://git-lfs.github.com/))
+- Git LFS (for large data files in the data repository. See [Git LFS Installation](https://git-lfs.github.com/))
 - Approximately 3GB of disk space for the full dataset and code
 - (Optional) Virtual environment tool (e.g., `venv`, `conda`)
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ This separation allows independent version control of code and data while mainta
 
 - Python 3.11 or later
 - Git (for cloning the repository)
+- Git LFS (for large data files in the data repository. See [Git LFS) Installation](https://git-lfs.github.com/))
+- Approximately 3GB of disk space for the full dataset and code
+- (Optional) Virtual environment tool (e.g., `venv`, `conda`)
 
 ### Installation
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import os
 from pathlib import Path
-from typing import Optional
 
 import pytest
 
@@ -10,7 +9,7 @@ from velocity_modelling.constants import (  # lazy resolver
 )
 
 
-def _env_path(var: str) -> Optional[Path]:
+def env_path(var: str) -> Path | None:
     val = os.environ.get(var)
     return Path(val).expanduser().resolve() if val else None
 
@@ -37,7 +36,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--nzvm-binary-path",
         action="store",
         type=Path,
-        default=_env_path("NZVM_BINARY_PATH"),
+        default=env_path("NZVM_BINARY_PATH"),
         help="Path to nzvm binary (or set NZVM_BINARY_PATH env var).",
     )
     parser.addoption(
@@ -68,7 +67,7 @@ def data_root(pytestconfig: pytest.Config) -> Path:
     4) sensible defaults
     5) interactive prompt (disabled in tests)
     """
-    cli_value: Optional[Path] = pytestconfig.getoption("--data-root")
+    cli_value: Path | None = pytestconfig.getoption("--data-root")
     resolved = get_data_root(str(cli_value) if cli_value else None)
     if not resolved.exists():
         raise FileNotFoundError(
@@ -79,8 +78,8 @@ def data_root(pytestconfig: pytest.Config) -> Path:
 
 
 @pytest.fixture(scope="session")
-def nzvm_binary_path(pytestconfig: pytest.Config) -> Optional[Path]:
-    p: Optional[Path] = pytestconfig.getoption("--nzvm-binary-path")
+def nzvm_binary_path(pytestconfig: pytest.Config) -> Path | None:
+    p: Path | None = pytestconfig.getoption("--nzvm-binary-path")
     return p.expanduser().resolve() if p else None
 
 

--- a/tests/test_gen_1dprofile_c_vs_python.py
+++ b/tests/test_gen_1dprofile_c_vs_python.py
@@ -103,6 +103,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from tests.conftest import env_path
+
 BASE_DIR = Path(__file__).parent.parent  # project root directory
 SCRIPT_DIR = BASE_DIR / "velocity_modelling/scripts"
 TEST_DIR = BASE_DIR / "tests"
@@ -110,9 +112,7 @@ TEST_DIR = BASE_DIR / "tests"
 MODEL_VERSIONS = ["2.08"]  # Fixed to known valid versions
 
 
-def generate_random_profile_config(
-    tmp_path: Path, output_dir: Path
-) -> tuple[Path, dict]:
+def generate_random_profile_config(profile_rootdir: Path) -> tuple[Path, dict]:
     """Generate a random profile config file for the C version."""
     profile_id = random.randint(100, 999)
     profile_lat = random.uniform(-45.0, -35.0)
@@ -124,7 +124,7 @@ def generate_random_profile_config(
     topo_type = random.choice(["TRUE", "BULLDOZED", "SQUASHED", "SQUASHED_TAPERED"])
     model_version = random.choice(MODEL_VERSIONS)
 
-    output_subdir = output_dir / "c_output" / str(profile_id)
+    output_subdir = profile_rootdir / "c_output" / str(profile_id)
     # Ensure C output directory doesn't exist before running C binary
     if output_subdir.exists():
         shutil.rmtree(output_subdir)
@@ -143,7 +143,7 @@ PROFILE_MIN_VS={min_vs}
 TOPO_TYPE={topo_type}
     """
 
-    config_path = tmp_path / f"nzcvm_profile_{profile_id}.cfg"
+    config_path = profile_rootdir / f"nzcvm_profile_{profile_id}.cfg"
     with open(config_path, "w") as f:
         f.write(config.strip())
         f.write("\n")
@@ -262,8 +262,9 @@ def test_gen_1dprofile_c_vs_python(
     nzvm_binary_path: Path,  # from conftest.py
     data_root: Path,  # from conftest.py
 ):
-    root_out_dir = tmp_path / "1d_profiles"
-    config_path, params = generate_random_profile_config(tmp_path, root_out_dir)
+    tmp_dir = env_path("JENKINS_OUTPUT_DIR") or tmp_path
+    profile_rootdir = tmp_dir / "1d_profiles"
+    config_path, params = generate_random_profile_config(profile_rootdir)
 
     # Run C binary from its directory with relative path
     c_result = subprocess.run(
@@ -283,8 +284,9 @@ def test_gen_1dprofile_c_vs_python(
         f"C binary failed with return code {c_result.returncode}: {c_result.stderr} (stdout: {c_result.stdout})"
     )
 
+    cid = params["id"]
     # Run Python version
-    location_csv = tmp_path / "locations.csv"
+    location_csv = profile_rootdir / f"locations_{cid}.csv"
     generate_location_csv(location_csv, params)
     py_result = subprocess.run(
         [
@@ -293,7 +295,7 @@ def test_gen_1dprofile_c_vs_python(
             "--model-version",
             params["model_version"],
             "--out-dir",
-            str(root_out_dir / "output"),
+            str(profile_rootdir / "output"),
             "--location-csv",
             str(location_csv),
             "--topo-type",
@@ -313,14 +315,14 @@ def test_gen_1dprofile_c_vs_python(
     assert py_result.returncode == 0, f"Python script failed: {py_result.stderr}"
 
     # Compare Profile
-    cid = params["id"]
+
     compare_profiles(
-        root_out_dir / f"c_output/{cid}/Profile/Profile.txt",
-        root_out_dir / f"output/Profiles/Profile_{cid}.txt",
+        profile_rootdir / f"c_output/{cid}/Profile/Profile.txt",
+        profile_rootdir / f"output/Profiles/Profile_{cid}.txt",
     )
     compare_surface_depths(
-        root_out_dir / f"c_output/{cid}/Profile/ProfileSurfaceDepths.txt",
-        root_out_dir / f"output/Profiles/ProfileSurfaceDepths_{cid}.txt",
+        profile_rootdir / f"c_output/{cid}/Profile/ProfileSurfaceDepths.txt",
+        profile_rootdir / f"output/Profiles/ProfileSurfaceDepths_{cid}.txt",
     )
 
 

--- a/tests/test_gen_3dvm_c_vs_python.py
+++ b/tests/test_gen_3dvm_c_vs_python.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from tests.conftest import env_path
 from velocity_modelling.tools.compare_emod3d import (
     compare_output_files,
     parse_nzcvm_config,
@@ -76,15 +77,17 @@ def test_gen_3dvm_c_vs_python(
 ):
     """Test C binary vs Python script with random config"""
     # Define output directories but don't create them yet
-    c_output_dir = tmp_path / "C"
-    python_output_dir = tmp_path / "Python"
+    tmp_dir = env_path("JENKINS_OUTPUT_DIR") or tmp_path
+
+    c_output_dir = tmp_dir / "C"
+    python_output_dir = tmp_dir / "Python"
 
     # Ensure C output directory doesn't exist before running C binary
     if c_output_dir.exists():
         shutil.rmtree(c_output_dir)
 
     # Generate random config with C output directory
-    config_file = generate_random_nzcvm_config(tmp_path, c_output_dir)
+    config_file = generate_random_nzcvm_config(tmp_dir, c_output_dir)
 
     # Run C binary from its directory with relative path
     c_result = subprocess.run(

--- a/tests/test_gen_3dvm_scenarios.py
+++ b/tests/test_gen_3dvm_scenarios.py
@@ -5,6 +5,7 @@ from typing import TypedDict
 
 import pytest
 
+from tests.conftest import env_path
 from velocity_modelling.tools.compare_emod3d import (
     compare_output_files,
     parse_nzcvm_config,
@@ -54,7 +55,8 @@ def scenario(
     scenario_path = SCENARIO_DIR / scenario_name
     config_file = scenario_path / "nzcvm.cfg"
     benchmark_path = test_paths[0] / scenario_name
-    output_path = tmp_path / scenario_name
+    tmp_dir = env_path("JENKINS_OUTPUT_DIR") or tmp_path
+    output_path = tmp_dir / scenario_name
     data_root = test_paths[1]
 
     return ScenarioDict(

--- a/velocity_modelling/data_helper.py
+++ b/velocity_modelling/data_helper.py
@@ -36,12 +36,23 @@ app = typer.Typer(
     help="""
 Helper to fetch/update the NZCVM data repository (no separate package required).
 
+Behavior:
+- Always re-aligns local repo to remote (fast-forward if possible, otherwise reset).
+- Fetches large LFS files by default (full dataset). Use --no-full to skip LFS.
+
 Examples:
-  nzcvm-data-helper ensure            # clone if missing, else pull (no LFS)
-  nzcvm-data-helper ensure --full     # clone/pull and fetch LFS files
-  nzcvm-data-helper ensure --path /data/nzcvm --repo <git-url> --branch develop --no-write-config
-  nzcvm-data-helper ensure --force  # force align to remote if not a fast-forward
-  nzcvm-data-helper where             # print configured data root
+  # Full dataset (default): clone if missing, else fetch/pull/reset, then fetch LFS
+  nzcvm-data-helper ensure
+
+  # Lightweight/CI: skip LFS (Only for testing or lightweight use cases. Not recommended for real use.)
+  nzcvm-data-helper ensure --no-full
+
+  # Use an already-cloned repo at a custom path, or specify remote/branch
+  nzcvm-data-helper ensure --path /data/nzcvm_data
+  nzcvm-data-helper ensure --repo https://github.com/ucgmsim/nzcvm_data.git --branch develop
+
+  # Print the currently configured data root
+  nzcvm-data-helper where
 """,
 )
 
@@ -193,6 +204,11 @@ def ensure(
     """
     _require_bin("git")
 
+    # If full dataset requested, require git-lfs *before* doing any clone/pull work.
+
+    if full:
+        _require_bin("git-lfs","git-lfs is required for full dataset. Install it or rerun with --no-full.")
+
     if not quiet:
         typer.echo(f"[{APP_NAME}] target: {path}")
 
@@ -254,19 +270,13 @@ def ensure(
             typer.echo(f"[{APP_NAME}] git clone failed", err=True)
             raise typer.Exit(code=1)
 
-    # Optionally fetch LFS assets
+    # Optionally fetch LFS assets (default = full)
     if full:
-        _require_bin(
-            "git-lfs",
-            "git-lfs is required for --full. Install it (See https://git-lfs.com) or rerun without --full.",
-        )
         # Install LFS hooks in this environment (safe if repeated)
         _run(["git", "-C", str(path), "lfs", "install"])
         if not quiet:
             typer.echo(f"[{APP_NAME}] fetching LFS objects...")
-        try:
-            _run(["git", "-C", str(path), "lfs", "pull"])
-        except subprocess.CalledProcessError:
+        if _run(["git", "-C", str(path), "lfs", "pull"]) != 0:
             typer.echo(f"[{APP_NAME}] git lfs pull failed", err=True)
             raise typer.Exit(code=1)
 

--- a/velocity_modelling/data_helper.py
+++ b/velocity_modelling/data_helper.py
@@ -207,7 +207,7 @@ def ensure(
     # If full dataset requested, require git-lfs *before* doing any clone/pull work.
 
     if full:
-        _require_bin("git-lfs","git-lfs is required for full dataset. Install it or rerun with --no-full.")
+        _require_bin("git-lfs","git-lfs is required for full dataset. Install git-lfs (See https://git-lfs.com) and try again.")
 
     if not quiet:
         typer.echo(f"[{APP_NAME}] target: {path}")

--- a/velocity_modelling/data_root.py
+++ b/velocity_modelling/data_root.py
@@ -120,6 +120,5 @@ def resolve_data_root(cli_override: str | None = None) -> Path:
         return p
 
     raise FileNotFoundError(
-        "Cannot locate NZCVM data root. Clone https://github.com/ucgmsim/nzcvm_data"
-        "and set --nzcvm-data-root or NZCVM_DATA_ROOT to its path."
+        "Cannot locate NZCVM data root. See README.md or Installation.md for setup instructions."
     )

--- a/velocity_modelling/global_model.py
+++ b/velocity_modelling/global_model.py
@@ -153,7 +153,7 @@ class PartialGlobalSurfaceDepths:
                 f"Error: Some depths not found in global sub-velocity model: {invalid_depths}"
             )
 
-        indices = np.searchsorted(self.depths[::-1], depths, side="right")
+        indices = np.searchsorted(self.depths[::-1], depths, side="left")
         n_velo_indices = len(self.depths) - indices - 1
 
         if np.any(n_velo_indices >= len(self.depths)):

--- a/velocity_modelling/global_model.py
+++ b/velocity_modelling/global_model.py
@@ -153,6 +153,10 @@ class PartialGlobalSurfaceDepths:
                 f"Error: Some depths not found in global sub-velocity model: {invalid_depths}"
             )
 
+        # for each x in "depths", find the index "j" of self.depths (ie. global surface depths) that satisfies
+        # self.depths[j] >= x > self.depths[j+1]
+        # Here, "j" is the index of the global sub-velocity model
+        # np.searchsorted finds the index where the element should be inserted to maintain order
         indices = np.searchsorted(self.depths[::-1], depths, side="left")
         n_velo_indices = len(self.depths) - indices - 1
 


### PR DESCRIPTION
This pull request introduces improvements to the CI pipeline, test output management, and code clarity, while also enhancing documentation and error handling. The main changes focus on making regression test outputs easier to archive and analyze, ensuring compatibility with Jenkins, improving type annotations in test fixtures, and clarifying requirements for dataset setup and Git LFS usage.

**CI/CD and Test Output Improvements:**
* Jenkins pipeline (`Jenkinsfile`): Regression test outputs are now written to a dedicated `test_output` directory, which is archived after each run for easier access and traceability. The environment variable `JENKINS_OUTPUT_DIR` is set to ensure consistency, and archiving is done even if the directory is empty.
* Test scripts (`tests/test_gen_1dprofile_c_vs_python.py`, `tests/test_gen_3dvm_c_vs_python.py`, `tests/test_gen_3dvm_scenarios.py`): Tests now use the `JENKINS_OUTPUT_DIR` environment variable for output directories when available, ensuring test artifacts are correctly routed and collected in CI environments. [[1]](diffhunk://#diff-1ec7a6ec48edd048c6766b3c13950028b8125f7ea2a09f7909cd6b54f6ff34c1L265-R267) [[2]](diffhunk://#diff-1f60308ae43b318b4d3f9e98940be4ff0ecd12ce0cc88687000940f16ae4932aL79-R90) [[3]](diffhunk://#diff-dc240dec5a08847378742d9e7809caab310e34fd971dd2027a5c8292c15b35a2L57-R59)

**Code Quality and Type Annotation Updates:**
* Test fixtures (`tests/conftest.py`): Type annotations have been modernized to use `Path | None` instead of `Optional[Path]`, and helper function names have been updated for clarity. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L3) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L13-R12) [[3]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L40-R39) [[4]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L71-R70) [[5]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L82-R82)

**Documentation and User Guidance:**
* Documentation (`README.md`): Installation requirements now explicitly mention the need for Git LFS, disk space requirements, and virtual environment tools, improving setup clarity for new users.
* Data helper script (`velocity_modelling/data_helper.py`): Usage instructions and behavior for data repository management have been clarified, especially regarding Git LFS and default behaviors for fetching large files. [[1]](diffhunk://#diff-bf87b2853bbdd4b53150805ce5660daf1e21b038c1508c183bbbf0ae57a887eeR39-R55) [[2]](diffhunk://#diff-bf87b2853bbdd4b53150805ce5660daf1e21b038c1508c183bbbf0ae57a887eeR207-R211) [[3]](diffhunk://#diff-bf87b2853bbdd4b53150805ce5660daf1e21b038c1508c183bbbf0ae57a887eeL257-R279)
* Data root error message (`velocity_modelling/data_root.py`): The error message when the NZCVM data root is missing now points users to the README and Installation guide for clearer setup instructions.

**Bug Fixes:**
* Velocity model indexing (`velocity_modelling/global_model.py`): The search direction for depth indices in the global velocity model has been corrected to use `side="left"` for proper matching.

For example,
```
self.depths=array([ 1000000., 0., -1000000.]) 
depths=array([ -0. , -34.78, -69.56, -104.34, ...])
```
For each element `x` in depths, I need to find index `j` of `self.depths` that satisfies

```
x <= self.depths[j] and x> self.depths[j+1]
```

and add `j` to `indices`.

So indices should be [1,1,1,1,1,1....]

However,
```
indices = np.searchsorted(self.depths[::-1], depths, side="right")
```
returns [2,1,1,1,1,1....]

Changing `side` to `left` fixes this problem.