### PR TITLE
Ayushi's request for 2.09

### DIFF
--- a/velocity_modelling/data_helper.py
+++ b/velocity_modelling/data_helper.py
@@ -207,7 +207,10 @@ def ensure(
     # If full dataset requested, require git-lfs *before* doing any clone/pull work.
 
     if full:
-        _require_bin("git-lfs","git-lfs is required for full dataset. Install git-lfs (See https://git-lfs.com) and try again.")
+        _require_bin(
+            "git-lfs",
+            "git-lfs is required for full dataset. Install git-lfs (See https://git-lfs.com) and try again.",
+        )
 
     if not quiet:
         typer.echo(f"[{APP_NAME}] target: {path}")

--- a/velocity_modelling/submodel/miocene_submod_v2.py
+++ b/velocity_modelling/submodel/miocene_submod_v2.py
@@ -1,0 +1,44 @@
+"""
+Miocene Layer Velocity Submodel v1
+
+This module provides velocity values for the Miocene geological layer.
+It implements depth-dependent velocity values based on empirical relationships
+for sedimentary rocks of Miocene age in the Canterbury basin.
+"""
+
+import logging
+from logging import Logger
+from typing import Optional
+
+import numpy as np
+
+from velocity_modelling.velocity3d import (
+    QualitiesVector,
+)
+
+
+def main_vectorized(
+    z_indices: np.ndarray,
+    qualities_vector: QualitiesVector,
+    logger: Optional[Logger] = None,
+):
+    """
+    Calculate rho, vp, and vs values for multiple lat-long-depth points in the Miocene layer.
+
+    Parameters
+    ----------
+    z_indices : np.ndarray
+        Array of indices of the grid points to store the data at.
+    qualities_vector : QualitiesVector
+        Object housing Vp, Vs, and Rho for one Lat-Lon value and multiple depths.
+    logger : Logger, optional
+        Logger for reporting processing status.
+    """
+    if logger is not None:
+        logger.log(
+            logging.DEBUG,
+            f"Assigning Miocene layer properties to {len(z_indices)} points",
+        )
+    qualities_vector.rho[z_indices] = 2.09
+    qualities_vector.vp[z_indices] = 2.5
+    qualities_vector.vs[z_indices] = 0.984

--- a/velocity_modelling/submodel/paleogene_submod_v2.py
+++ b/velocity_modelling/submodel/paleogene_submod_v2.py
@@ -1,0 +1,46 @@
+"""
+Paleogene Layer Velocity Submodel v1
+
+This module provides velocity values for the Paleogene geological layer.
+It implements depth-dependent velocity values based on empirical relationships
+for sedimentary rocks of Paleogene age in the Canterbury basin.
+"""
+
+import logging
+from logging import Logger
+from typing import Optional
+
+import numpy as np
+
+from velocity_modelling.velocity3d import (
+    QualitiesVector,
+)
+
+
+def main_vectorized(
+    z_indices: np.ndarray,
+    qualities_vector: QualitiesVector,
+    logger: Optional[Logger] = None,
+):
+    """
+    Calculate rho, vp, and vs values for multiple lat-long-depth points in the Paleogene layer.
+
+    Parameters
+    ----------
+    z_indices : np.ndarray
+        Array of indices of the grid points to store the data at.
+    qualities_vector : QualitiesVector
+        Object housing Vp, Vs, and Rho for one Lat-Lon value and multiple depths.
+    logger : Logger, optional
+        Logger for reporting processing status.
+    """
+
+    if logger is not None:
+        logger.log(
+            logging.DEBUG,
+            f"Assigning Paleogene layer properties to {len(z_indices)} points",
+        )
+
+    qualities_vector.rho[z_indices] = 2.19
+    qualities_vector.vp[z_indices] = 2.85
+    qualities_vector.vs[z_indices] = 1.281

--- a/velocity_modelling/submodel/palmerstonnorth_pliocene_submod_v1.py
+++ b/velocity_modelling/submodel/palmerstonnorth_pliocene_submod_v1.py
@@ -1,0 +1,45 @@
+"""
+Pliocene Layer Velocity Submodel v1
+
+This module provides velocity values for the Pliocene geological layer.
+It implements depth-dependent velocity values based on empirical relationships
+for sedimentary rocks of Pliocene age in the Canterbury basin.
+"""
+
+import logging
+from logging import Logger
+from typing import Optional
+
+import numpy as np
+
+from velocity_modelling.velocity3d import (
+    QualitiesVector,
+)
+
+
+def main_vectorized(
+    z_indices: np.ndarray,
+    qualities_vector: QualitiesVector,
+    logger: Optional[Logger] = None,
+):
+    """
+    Calculate rho, vp, and vs values for multiple lat-long-depth points in the Pliocene layer.
+
+    Parameters
+    ----------
+    z_indices : np.ndarray
+        Array of indices of the grid points to store the data at.
+    qualities_vector : QualitiesVector
+        Object housing Vp, Vs, and Rho for one Lat-Lon value and multiple depths.
+    logger : Logger, optional
+        Logger for reporting processing
+    """
+    if logger is not None:
+        logger.log(
+            logging.DEBUG,
+            f"Assigning Pliocene layer properties to {len(z_indices)} points",
+        )
+
+    qualities_vector.rho[z_indices] = 2.12
+    qualities_vector.vp[z_indices] = 2.6
+    qualities_vector.vs[z_indices] = 1.1

--- a/velocity_modelling/submodel/pliocene_submod_v2.py
+++ b/velocity_modelling/submodel/pliocene_submod_v2.py
@@ -1,0 +1,45 @@
+"""
+Pliocene Layer Velocity Submodel v1
+
+This module provides velocity values for the Pliocene geological layer.
+It implements depth-dependent velocity values based on empirical relationships
+for sedimentary rocks of Pliocene age in the Canterbury basin.
+"""
+
+import logging
+from logging import Logger
+from typing import Optional
+
+import numpy as np
+
+from velocity_modelling.velocity3d import (
+    QualitiesVector,
+)
+
+
+def main_vectorized(
+    z_indices: np.ndarray,
+    qualities_vector: QualitiesVector,
+    logger: Optional[Logger] = None,
+):
+    """
+    Calculate rho, vp, and vs values for multiple lat-long-depth points in the Pliocene layer.
+
+    Parameters
+    ----------
+    z_indices : np.ndarray
+        Array of indices of the grid points to store the data at.
+    qualities_vector : QualitiesVector
+        Object housing Vp, Vs, and Rho for one Lat-Lon value and multiple depths.
+    logger : Logger, optional
+        Logger for reporting processing
+    """
+    if logger is not None:
+        logger.log(
+            logging.DEBUG,
+            f"Assigning Pliocene layer properties to {len(z_indices)} points",
+        )
+
+    qualities_vector.rho[z_indices] = 1.95
+    qualities_vector.vp[z_indices] = 2.1
+    qualities_vector.vs[z_indices] = 0.677

--- a/velocity_modelling/velocity3d.py
+++ b/velocity_modelling/velocity3d.py
@@ -662,6 +662,9 @@ class QualitiesVector:
             "canterbury1d_v1",
             "canterbury1d_v2",
             "canterbury1d_v2_pliocene_enforced",
+            "canterbury1d_v3_pliocene_enforced",
+            "nelson_v1",
+            "palmerstonnorth_v1",
         ]:
             from velocity_modelling.submodel import canterbury1d_submod
 
@@ -677,7 +680,22 @@ class QualitiesVector:
         elif submodel_name == "miocene_submod_v1":
             from velocity_modelling.submodel import miocene_submod_v1
 
-            miocene_submod_v1.main_vectorized(z_indices, self)
+        elif submodel_name == "paleogene_submod_v2":
+            from velocity_modelling.submodel import paleogene_submod_v2
+
+            paleogene_submod_v2.main_vectorized(z_indices, self)
+        elif submodel_name == "pliocene_submod_v2":
+            from velocity_modelling.submodel import pliocene_submod_v2
+
+            pliocene_submod_v2.main_vectorized(z_indices, self)
+        elif submodel_name == "miocene_submod_v2":
+            from velocity_modelling.submodel import miocene_submod_v2
+
+            miocene_submod_v2.main_vectorized(z_indices, self)
+        elif submodel_name == "palmerstonnorth_pliocene_submod_v1":
+            from velocity_modelling.submodel import palmerstonnorth_pliocene_submod_v1
+
+            palmerstonnorth_pliocene_submod_v1.main_vectorized(z_indices, self)
         elif submodel_name == "bpv_submod_v1":
             from velocity_modelling.submodel import bpv_submod_v1
 

--- a/velocity_modelling/velocity3d.py
+++ b/velocity_modelling/velocity3d.py
@@ -680,6 +680,7 @@ class QualitiesVector:
         elif submodel_name == "miocene_submod_v1":
             from velocity_modelling.submodel import miocene_submod_v1
 
+            miocene_submod_v1.main_vectorized(z_indices, self)
         elif submodel_name == "paleogene_submod_v2":
             from velocity_modelling.submodel import paleogene_submod_v2
 


### PR DESCRIPTION
This pull request introduces several new geological layer submodels and integrates them into the vectorized velocity calculation pipeline. The main focus is on expanding support for different sedimentary layers in the Canterbury basin and Palmerston North region, with each submodel providing depth-dependent velocity properties. Additionally, there is a minor formatting update in the data helper utility.

Relevant changes to nzcvm_data are:
https://github.com/ucgmsim/nzcvm_data/commit/af06fcb202d820a2128f313ed437b16b0d1a1a96
https://github.com/ucgmsim/nzcvm_data/commit/1ba583eb7c4073b50b7aecfd2040b01916691135


**New submodels for geological layers:**

* Added new submodel files for Miocene (`miocene_submod_v2.py`), Paleogene (`paleogene_submod_v2.py`), Pliocene (`pliocene_submod_v2.py`), and Palmerston North Pliocene (`palmerstonnorth_pliocene_submod_v1.py`) layers, each implementing a `main_vectorized` function to assign velocity and density properties for multiple grid points. [[1]](diffhunk://#diff-07ca034c7d2701bd6863c2824a04288c592aa07ff159fb7cb1f5daadc60d030bR1-R44) [[2]](diffhunk://#diff-6f1e61e0c4c969b8ef4fea63a9f99de8cbc1f8167afd1bd51abcc122b7025eb8R1-R46) [[3]](diffhunk://#diff-5369d1593d5d7f1d3c6457d7b0439defb4713420e0b084b46df32dd0094786bbR1-R45) [[4]](diffhunk://#diff-4d6c9796db9aea03d6e2aed29d29f9ca0c1a5706c73a0c59300acf744673ce11R1-R45)

**Integration of submodels into the velocity calculation pipeline:**

* Updated `call_basin_submodel_vectorized` in `velocity3d.py` to support the new submodels, allowing selection and execution of the appropriate submodel based on the provided name.

**Support for additional basin models:**

* Extended the list of supported basin model names in `velocity3d.py` to include `canterbury1d_v3_pliocene_enforced`, `nelson_v1`, and `palmerstonnorth_v1`.

**Minor code quality improvement:**

* Improved formatting for the `git-lfs` requirement check in `data_helper.py` for better readability and maintainability.

**Note:** **I don't like** how submodels are currently handled - will address the following issues in the up-coming PR.
(1) it sits somewhere between the data and the code - nzcvm_registry.yaml is pointing to .py files in a separate repository feels wrong.
(2) Some names are misleading : `ep_tomography_submod_v2010.py` assuming Eberhart-Phillips ("ep-") and handling v2010, v2020, v2025 etc. It can be a generic "tomography_submodel.py". Similarly `canterbury1d_submod.py` can be `vm1d_submod.py`
(3) All other constant value type submodels `miocene_submod_v1.py` etc. can be just registered as vp=x, vs=y, rho=z in the registry. 
