### PR TITLE
Parallelisation of generate_3d_model

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,19 +135,19 @@ pipeline {
                         }
                     }
                     post {
-                        failure {
+                        always {
                             script {
                                 def test_output_dir = "${env.WORKSPACE}/test_output-${env.BUILD_ID}"
                                 archiveArtifacts artifacts: "${test_output_dir}/**", allowEmptyArchive: true
                             }
                         }
-                        success {
-                            script {
-                                // Only cleanup on success
-                                def test_output_dir = "${env.WORKSPACE}/test_output-${env.BUILD_ID}"
-                                sh "rm -rf ${test_output_dir}"
-                            }
-                        }
+//                         success {
+//                             script {
+//                                 // Only cleanup on success
+//                                 def test_output_dir = "${env.WORKSPACE}/test_output-${env.BUILD_ID}"
+//                                 sh "rm -rf ${test_output_dir}"
+//                             }
+//                         }
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
 
                             # Verify critical files exist and aren't LFS pointers
                             echo "Verifying LFS files..."
-                            if find . -name "*.dat" -exec file {} \\; | grep -q "ASCII text"; then
+                            if find . -name "*.h5" -exec file {} \\; | grep -q "ASCII text"; then
                                 echo "ERROR: Found LFS pointer files instead of actual data"
                                 exit 1
                             fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,7 +142,7 @@ pipeline {
                         always {
                             script {
                                 def test_output_dir = "${env.WORKSPACE}/test_output-${env.BUILD_ID}"
-                                archiveArtifacts artifacts: "${test_output_dir}/**", allowEmptyArchive: true
+                                archiveArtifacts artifacts: "test_output-${env.BUILD_ID}/**", allowEmptyArchive: true
                             }
                         }
                         success {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,10 @@ pipeline {
                     retry(3) {
                         sh """
                             cd /mnt/mantle_data/jenkins/nzvm/nzcvm_data
+
+                            # Fix the dubious ownership issue
+                            git config --global --add safe.directory /mnt/mantle_data/jenkins/nzvm/nzcvm_data
+
                             git config pull.rebase false
                             git pull origin main
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ pipeline {
             steps {
                 sh """
                     cd /mnt/mantle_data/jenkins/nzvm/nzcvm_data
+                    git config pull.rebase false
                     git pull origin main
                     git lfs pull
                 """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -139,7 +139,7 @@ pipeline {
                         }
                     }
                     post {
-                        always {
+                        failure {
                             script {
                                 def test_output_dir = "${env.WORKSPACE}/test_output-${env.BUILD_ID}"
                                 archiveArtifacts artifacts: "test_output-${env.BUILD_ID}/**", allowEmptyArchive: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,13 +145,13 @@ pipeline {
                                 archiveArtifacts artifacts: "${test_output_dir}/**", allowEmptyArchive: true
                             }
                         }
-//                         success {
-//                             script {
-//                                 // Only cleanup on success
-//                                 def test_output_dir = "${env.WORKSPACE}/test_output-${env.BUILD_ID}"
-//                                 sh "rm -rf ${test_output_dir}"
-//                             }
-//                         }
+                        success {
+                            script {
+                                // Only cleanup on success
+                                def test_output_dir = "${env.WORKSPACE}/test_output-${env.BUILD_ID}"
+                                sh "rm -rf ${test_output_dir}"
+                            }
+                        }
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,16 +8,42 @@ pipeline {
                 sh 'docker pull earthquakesuc/nzvm'
             }
         }
-
         stage('Update nzcvm_data Repository') {
             agent any
+            options {
+                timeout(time: 30, unit: 'MINUTES')
+            }
             steps {
-                sh """
-                    cd /mnt/mantle_data/jenkins/nzvm/nzcvm_data
-                    git config pull.rebase false
-                    git pull origin main
-                    git lfs pull
-                """
+                script {
+                    retry(3) {
+                        sh """
+                            cd /mnt/mantle_data/jenkins/nzvm/nzcvm_data
+                            git config pull.rebase false
+                            git pull origin main
+
+                            # Clear any partial LFS downloads
+                            git lfs prune
+
+                            # Pull with explicit timeout
+                            timeout 20m git lfs pull
+
+                            # Verify critical files exist and aren't LFS pointers
+                            echo "Verifying LFS files..."
+                            if find . -name "*.dat" -exec file {} \\; | grep -q "ASCII text"; then
+                                echo "ERROR: Found LFS pointer files instead of actual data"
+                                exit 1
+                            fi
+
+                            # Ensure we have actual data files
+                            data_size=\$(du -sm . | cut -f1)
+                            echo "Data directory size: \${data_size}MB"
+                            if [ "\$data_size" -lt 100 ]; then  # Adjust threshold as needed
+                                echo "ERROR: Data directory too small (\${data_size}MB), likely incomplete"
+                                exit 1
+                            fi
+                        """
+                    }
+                }
             }
         }
 
@@ -78,9 +104,29 @@ pipeline {
                                 sh """
                                     cd ${env.WORKSPACE}
                                     source .venv/bin/activate
+                                    # Verify mount exists before creating symlink
+                                    if [ ! -d "/nzvm/nzcvm_data" ]; then
+                                        echo "ERROR: Mount /nzvm/nzcvm_data does not exist"
+                                        exit 1
+                                    fi
+                                    # Check mount is not empty
+                                    if [ ! "\$(ls -A /nzvm/nzcvm_data 2>/dev/null)" ]; then
+                                        echo "ERROR: Mount /nzvm/nzcvm_data is empty"
+                                        ls -la /nzvm/ || echo "Could not list /nzvm/"
+                                        exit 1
+                                    fi
+
                                     rm -f ${env.WORKSPACE}/velocity_modelling/nzcvm_data
                                     ln -s /nzvm/nzcvm_data ${env.WORKSPACE}/velocity_modelling/nzcvm_data
 
+                                    # Verify symlink works
+                                    if [ ! -r "${env.WORKSPACE}/velocity_modelling/nzcvm_data" ]; then
+                                        echo "ERROR: Symlink is not readable"
+                                        ls -la ${env.WORKSPACE}/velocity_modelling/
+                                        exit 1
+                                    fi
+
+                                    echo "Data verification passed, starting tests..."
                                     # Create the unique test output directory
                                     mkdir -p ${test_output_dir}
                                     pytest -s tests/ --benchmark-dir /nzvm/benchmarks --nzvm-binary-path /nzvm/NZVM --data-root ${env.WORKSPACE}/velocity_modelling/nzcvm_data
@@ -89,11 +135,10 @@ pipeline {
                         }
                     }
                     post {
-                        always {
+                        failure {
                             script {
                                 def test_output_dir = "${env.WORKSPACE}/test_output-${env.BUILD_ID}"
                                 archiveArtifacts artifacts: "${test_output_dir}/**", allowEmptyArchive: true
-                                sh "rm -rf ${test_output_dir}"
                             }
                         }
                         success {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,10 +88,11 @@ pipeline {
                         }
                     }
                     post {
-                        failure {
+                        always {
                             script {
                                 def test_output_dir = "${env.WORKSPACE}/test_output-${env.BUILD_ID}"
                                 archiveArtifacts artifacts: "${test_output_dir}/**", allowEmptyArchive: true
+                                sh "rm -rf ${test_output_dir}"
                             }
                         }
                         success {

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ numba
 pyyaml
 tqdm
 typer
+threadpoolctl
 
 # Tool dependencies
 cartopy

--- a/tests/test_gen_3dvm_c_vs_python.py
+++ b/tests/test_gen_3dvm_c_vs_python.py
@@ -2,7 +2,7 @@ import os
 import random
 import shutil
 import subprocess
-import uuid  # add
+import uuid
 from pathlib import Path
 
 import pytest

--- a/tests/test_gen_3dvm_c_vs_python.py
+++ b/tests/test_gen_3dvm_c_vs_python.py
@@ -3,6 +3,7 @@ import random
 import shutil
 import subprocess
 from pathlib import Path
+import uuid  # add
 
 import pytest
 
@@ -63,8 +64,6 @@ OUTPUT_DIR={c_output_dir}
     # Debug: Verify file exists and print content
     assert config_file.exists(), f"Config file {config_file} was not created"
     assert os.access(config_file, os.R_OK), f"Config file {config_file} is not readable"
-    with open(config_file, "r") as f:
-        print(f"Generated config file content:\n{f.read()}")
 
     return config_file
 
@@ -76,8 +75,11 @@ def test_gen_3dvm_c_vs_python(
     data_root: Path,  # provided by conftest.py
 ):
     """Test C binary vs Python script with random config"""
-    # Define output directories but don't create them yet
-    tmp_dir = env_path("JENKINS_OUTPUT_DIR") or tmp_path
+    # Define output directories with a unique per-run hash
+    base_tmp_dir = env_path("JENKINS_OUTPUT_DIR") or tmp_path
+    unique_id = uuid.uuid4().hex[:8]
+    tmp_dir = base_tmp_dir / unique_id
+    tmp_dir.mkdir(parents=True, exist_ok=True)
 
     c_output_dir = tmp_dir / "C"
     python_output_dir = tmp_dir / "Python"
@@ -165,7 +167,7 @@ def test_gen_3dvm_c_vs_python(
         print("=" * 50)
 
     # Single assertion based on collected failures
-    assert not failed_keys, f"Comparison failed for: {', '.join(failed_keys)}"
+    assert not failed_keys, f"Test {unique_id}  Comparison failed for: {', '.join(failed_keys)}"
 
 
 if __name__ == "__main__":

--- a/tests/test_gen_3dvm_c_vs_python.py
+++ b/tests/test_gen_3dvm_c_vs_python.py
@@ -110,6 +110,21 @@ def test_gen_3dvm_c_vs_python(
     )
     print(f"C binary wrote to expected directory: {c_velocity_model_dir}")
 
+    print(f"=== TEST DEBUG ===")
+    print(f"data_root fixture value: {data_root}")
+    print(f"data_root type: {type(data_root)}")
+    print(f"data_root exists: {data_root.exists()}")
+    print(f"Full subprocess command: {[
+        'python',
+        str(SCRIPT_DIR / 'generate_3d_model.py'),
+        str(config_file),
+        '--out-dir',
+        str(python_output_dir),
+        '--nzcvm-data-root',
+        str(data_root),
+    ]}")
+    print("==================")
+
     # Run Python script, overriding output directory
     python_result = subprocess.run(
         [
@@ -124,6 +139,7 @@ def test_gen_3dvm_c_vs_python(
         capture_output=True,
         text=True,
     )
+
     assert python_result.returncode == 0, (
         f"Python script failed: {python_result.stderr}"
     )

--- a/tests/test_gen_3dvm_c_vs_python.py
+++ b/tests/test_gen_3dvm_c_vs_python.py
@@ -114,15 +114,7 @@ def test_gen_3dvm_c_vs_python(
     print(f"data_root fixture value: {data_root}")
     print(f"data_root type: {type(data_root)}")
     print(f"data_root exists: {data_root.exists()}")
-    print(f"Full subprocess command: {[
-        'python',
-        str(SCRIPT_DIR / 'generate_3d_model.py'),
-        str(config_file),
-        '--out-dir',
-        str(python_output_dir),
-        '--nzcvm-data-root',
-        str(data_root),
-    ]}")
+    print(f"Full subprocess command: ['python',{str(SCRIPT_DIR)} / 'generate_3d_model.py', {str(config_file)}, '--out-dir',{str(python_output_dir)}, '--nzcvm-data-root', {str(data_root)}]")
     print("==================")
 
     # Run Python script, overriding output directory

--- a/tests/test_gen_3dvm_c_vs_python.py
+++ b/tests/test_gen_3dvm_c_vs_python.py
@@ -149,14 +149,15 @@ def test_gen_3dvm_c_vs_python(
             failed_keys.append(f"{key} (size check failed)")
         elif not comparison_results[key]["allclose"]:
             failed_keys.append(
-                f"{key} (max diff: {comparison_results[key]['max_diff']}, mean diff: {comparison_results[key]['mean_diff']})")
+                f"{key} (max diff: {comparison_results[key]['max_diff']}, mean diff: {comparison_results[key]['mean_diff']})"
+            )
 
     # Dump debugging info once if any failures occurred
     if failed_keys:
-        print(f"\n=== DEBUGGING INFO FOR FAILED COMPARISON ===")
+        print("\n=== DEBUGGING INFO FOR FAILED COMPARISON ===")
         print(f"Config file path: {config_file}")
         try:
-            with open(config_file, 'r') as f:
+            with open(config_file, "r") as f:
                 config_content = f.read()
             print(f"Config file contents:\n{config_content}")
         except Exception as e:
@@ -165,6 +166,7 @@ def test_gen_3dvm_c_vs_python(
 
     # Single assertion based on collected failures
     assert not failed_keys, f"Comparison failed for: {', '.join(failed_keys)}"
+
 
 if __name__ == "__main__":
     pytest.main(["-v"])

--- a/tests/test_gen_3dvm_c_vs_python.py
+++ b/tests/test_gen_3dvm_c_vs_python.py
@@ -108,16 +108,6 @@ def test_gen_3dvm_c_vs_python(
     assert c_velocity_model_dir.exists() and any(c_velocity_model_dir.iterdir()), (
         f"No output found in {c_velocity_model_dir}"
     )
-    print(f"C binary wrote to expected directory: {c_velocity_model_dir}")
-
-    print("=== TEST DEBUG ===")
-    print(f"data_root fixture value: {data_root}")
-    print(f"data_root type: {type(data_root)}")
-    print(f"data_root exists: {data_root.exists()}")
-    print(
-        f"Full subprocess command: ['python',{str(SCRIPT_DIR)} / 'generate_3d_model.py', '{str(config_file)}', '--out-dir','{str(python_output_dir)}', '--nzcvm-data-root', '{str(data_root)}']"
-    )
-    print("==================")
 
     # Run Python script, overriding output directory
     python_result = subprocess.run(
@@ -133,13 +123,6 @@ def test_gen_3dvm_c_vs_python(
         capture_output=True,
         text=True,
     )
-
-    # ADD THIS TO SEE THE ACTUAL OUTPUT:
-    print("=== SUBPROCESS OUTPUT ===")
-    print(f"Return code: {python_result.returncode}")
-    print(f"STDOUT: {python_result.stdout}")
-    print(f"STDERR: {python_result.stderr}")
-    print("========================")
 
     assert python_result.returncode == 0, (
         f"Python script failed: {python_result.stderr}"

--- a/tests/test_gen_3dvm_c_vs_python.py
+++ b/tests/test_gen_3dvm_c_vs_python.py
@@ -110,11 +110,13 @@ def test_gen_3dvm_c_vs_python(
     )
     print(f"C binary wrote to expected directory: {c_velocity_model_dir}")
 
-    print(f"=== TEST DEBUG ===")
+    print("=== TEST DEBUG ===")
     print(f"data_root fixture value: {data_root}")
     print(f"data_root type: {type(data_root)}")
     print(f"data_root exists: {data_root.exists()}")
-    print(f"Full subprocess command: ['python',{str(SCRIPT_DIR)} / 'generate_3d_model.py', '{str(config_file)}', '--out-dir','{str(python_output_dir)}', '--nzcvm-data-root', '{str(data_root)}']")
+    print(
+        f"Full subprocess command: ['python',{str(SCRIPT_DIR)} / 'generate_3d_model.py', '{str(config_file)}', '--out-dir','{str(python_output_dir)}', '--nzcvm-data-root', '{str(data_root)}']"
+    )
     print("==================")
 
     # Run Python script, overriding output directory
@@ -133,7 +135,7 @@ def test_gen_3dvm_c_vs_python(
     )
 
     # ADD THIS TO SEE THE ACTUAL OUTPUT:
-    print(f"=== SUBPROCESS OUTPUT ===")
+    print("=== SUBPROCESS OUTPUT ===")
     print(f"Return code: {python_result.returncode}")
     print(f"STDOUT: {python_result.stdout}")
     print(f"STDERR: {python_result.stderr}")

--- a/tests/test_gen_3dvm_c_vs_python.py
+++ b/tests/test_gen_3dvm_c_vs_python.py
@@ -114,7 +114,7 @@ def test_gen_3dvm_c_vs_python(
     print(f"data_root fixture value: {data_root}")
     print(f"data_root type: {type(data_root)}")
     print(f"data_root exists: {data_root.exists()}")
-    print(f"Full subprocess command: ['python',{str(SCRIPT_DIR)} / 'generate_3d_model.py', {str(config_file)}, '--out-dir',{str(python_output_dir)}, '--nzcvm-data-root', {str(data_root)}]")
+    print(f"Full subprocess command: ['python',{str(SCRIPT_DIR)} / 'generate_3d_model.py', '{str(config_file)}', '--out-dir','{str(python_output_dir)}', '--nzcvm-data-root', '{str(data_root)}']")
     print("==================")
 
     # Run Python script, overriding output directory
@@ -131,6 +131,13 @@ def test_gen_3dvm_c_vs_python(
         capture_output=True,
         text=True,
     )
+
+    # ADD THIS TO SEE THE ACTUAL OUTPUT:
+    print(f"=== SUBPROCESS OUTPUT ===")
+    print(f"Return code: {python_result.returncode}")
+    print(f"STDOUT: {python_result.stdout}")
+    print(f"STDERR: {python_result.stderr}")
+    print("========================")
 
     assert python_result.returncode == 0, (
         f"Python script failed: {python_result.stderr}"

--- a/tests/test_gen_3dvm_c_vs_python.py
+++ b/tests/test_gen_3dvm_c_vs_python.py
@@ -2,8 +2,8 @@ import os
 import random
 import shutil
 import subprocess
-from pathlib import Path
 import uuid  # add
+from pathlib import Path
 
 import pytest
 
@@ -167,7 +167,9 @@ def test_gen_3dvm_c_vs_python(
         print("=" * 50)
 
     # Single assertion based on collected failures
-    assert not failed_keys, f"Test {unique_id}  Comparison failed for: {', '.join(failed_keys)}"
+    assert not failed_keys, (
+        f"Test {unique_id}  Comparison failed for: {', '.join(failed_keys)}"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_gen_3dvm_c_vs_python.py
+++ b/tests/test_gen_3dvm_c_vs_python.py
@@ -157,10 +157,10 @@ def test_gen_3dvm_c_vs_python(
         print("\n=== DEBUGGING INFO FOR FAILED COMPARISON ===")
         print(f"Config file path: {config_file}")
         try:
-            with open(config_file, "r") as f:
+            with open(config_file, "r", encoding="utf-8") as f:
                 config_content = f.read()
             print(f"Config file contents:\n{config_content}")
-        except Exception as e:
+        except (OSError, UnicodeDecodeError) as e:
             print(f"Could not read config file: {e}")
         print("=" * 50)
 

--- a/velocity_modelling/basin_model.py
+++ b/velocity_modelling/basin_model.py
@@ -133,6 +133,30 @@ def determine_basin_contains_lat_lon(
 
     return False
 
+_WORK_INB = None
+_WORK_PGM_LIST = None
+
+def _init_inbasin_worker(in_basin_mesh, partial_global_mesh_list):
+    # Called once in each worker
+    global _WORK_INB, _WORK_PGM_LIST
+    _WORK_INB = in_basin_mesh
+    _WORK_PGM_LIST = partial_global_mesh_list
+
+def _compute_membership_row(j: int):
+    """
+    Compute basin membership for one row j.
+    Returns (j, row_list), where row_list is a list of lists of basin indices with length nx.
+    """
+    in_basin_mesh = _WORK_INB
+    pgm = _WORK_PGM_LIST[j]
+    nx = in_basin_mesh.nx
+    row = [[] for _ in range(nx)]
+    # identical to your serial inner loop
+    for k in range(nx):
+        lat = pgm.lat[k]
+        lon = pgm.lon[k]
+        row[k] = in_basin_mesh.find_all_containing_basins(lat, lon)
+    return j, row
 
 class InBasinGlobalMesh:
     """
@@ -210,6 +234,7 @@ class InBasinGlobalMesh:
         basin_data_list: list[BasinData],
         logger: Optional[Logger] = None,
         smooth_bound: Optional[SmoothingBoundary] = None,
+        np_workers: int | None = None,
     ) -> tuple[Self, list[PartialGlobalMesh]]:
         """
         Preprocess basin membership for a given global mesh to speed up the velocity model generation
@@ -225,6 +250,8 @@ class InBasinGlobalMesh:
             Logger for status reporting.
         smooth_bound : SmoothingBoundary, optional
             Optional boundary for smoothing.
+        np_workers : int, optional
+            Number of workers for parallel processing (default is None).
 
         Returns
         -------
@@ -238,9 +265,7 @@ class InBasinGlobalMesh:
 
         # Use object dtype to store lists of basin indices
         # Initialize basin_membership as an (ny, nx) array of empty lists
-        in_basin_mesh.basin_membership = [
-            [[] for _ in range(in_basin_mesh.nx)] for _ in range(in_basin_mesh.ny)
-        ]
+        in_basin_mesh.basin_membership = [ [[] for _ in range(in_basin_mesh.nx)] for _ in range(in_basin_mesh.ny) ]
 
         boundary_arrays = [
             np.vstack(basin.boundaries)  # Merge all boundary arrays for each basin
@@ -283,14 +308,45 @@ class InBasinGlobalMesh:
             PartialGlobalMesh(global_mesh, j) for j in range(ny)
         ]
 
-        for j in range(ny):
-            partial_global_mesh = partial_global_mesh_list[j]
-            for k in range(nx):
-                lat = partial_global_mesh.lat[k]
-                lon = partial_global_mesh.lon[k]
-                in_basin_mesh.basin_membership[j][k] = (
-                    in_basin_mesh.find_all_containing_basins(lat, lon)
-                )
+        use_workers = (np_workers or 1) > 1 and ny > 1
+
+        if use_workers:
+            import os, multiprocessing as mp
+            from concurrent.futures import ProcessPoolExecutor, as_completed
+            W = min(np_workers or (os.cpu_count() or 1), ny)
+
+            # Prefer 'fork' on Linux to inherit big, read-only objects without pickling
+            try:
+                ctx = mp.get_context("fork")
+                start_method = "fork"
+            except ValueError:
+                # Fallback: spawn (safe everywhere, but will pickle more)
+                ctx = mp.get_context("spawn")
+                start_method = "spawn"
+
+            if logger:
+                logger.log(logging.INFO, f"Parallelizing basin membership over rows: workers={W} ({start_method}).")
+
+            with ProcessPoolExecutor(
+                max_workers=W,
+                mp_context=ctx,
+                initializer=_init_inbasin_worker,
+                initargs=(in_basin_mesh, partial_global_mesh_list),
+            ) as ex:
+                futures = [ex.submit(_compute_membership_row, j) for j in range(ny)]
+                for fut in as_completed(futures):
+                    j, row = fut.result()
+                    in_basin_mesh.basin_membership[j] = row
+        else:
+            # --- Serial fallback (default) ---
+            for j in range(ny):
+                pgm = partial_global_mesh_list[j]
+                for k in range(nx):
+                    lat = pgm.lat[k]
+                    lon = pgm.lon[k]
+                    in_basin_mesh.basin_membership[j][k] = (
+                        in_basin_mesh.find_all_containing_basins(lat, lon)
+                    )
 
         logger.log(
             logging.INFO,

--- a/velocity_modelling/basin_model.py
+++ b/velocity_modelling/basin_model.py
@@ -339,9 +339,9 @@ class InBasinGlobalMesh:
             PartialGlobalMesh(global_mesh, j) for j in range(ny)
         ]
 
-        use_workers = (np_workers or 1) > 1 and ny > 1
+        is_parallel = (np_workers or 1) > 1 and ny > 1
 
-        if use_workers:
+        if is_parallel:
             import multiprocessing as mp
             import os
             from concurrent.futures import ProcessPoolExecutor, as_completed

--- a/velocity_modelling/basin_model.py
+++ b/velocity_modelling/basin_model.py
@@ -6,6 +6,8 @@ determination in the velocity model. It handles basin boundaries, surfaces, and 
 with proper logging throughout the processing workflow.
 """
 
+from __future__ import annotations
+
 import logging
 from logging import Logger
 from pathlib import Path
@@ -139,8 +141,8 @@ _WORK_PGM_LIST = None
 
 
 def _init_inbasin_worker(
-    in_basin_mesh: "InBasinGlobalMesh",
-    partial_global_mesh_list: list["PartialGlobalMesh"],
+    in_basin_mesh: InBasinGlobalMesh,
+    partial_global_mesh_list: list[PartialGlobalMesh],
 ) -> None:
     """
     Initialize worker process with shared data for parallel basin membership computation.

--- a/velocity_modelling/constants.py
+++ b/velocity_modelling/constants.py
@@ -57,7 +57,20 @@ def get_data_root(cli_override: str | None = None) -> Path:
 
 
 def get_registry_path(data_root: Path | None = None) -> Path:
-    """Get registry path, using provided data_root if given."""
+    """
+    Get registry path, using provided data_root if given.
+
+    Parameters
+    ----------
+    data_root : Path | None
+        If provided, use this as the data root.
+
+    Returns
+    -------
+    Path
+        Path to nzcvm_registry.yaml.
+
+    """
     if data_root is None:
         data_root = get_data_root()  # Fall back to default resolution
 

--- a/velocity_modelling/constants.py
+++ b/velocity_modelling/constants.py
@@ -56,23 +56,12 @@ def get_data_root(cli_override: str | None = None) -> Path:
     return _DATA_ROOT
 
 
-def get_registry_path(cli_override: str | None = None) -> Path:
-    """
-    Get the path to the nzcvm_registry.yaml file.
+def get_registry_path(data_root: Path | None = None) -> Path:
+    """Get registry path, using provided data_root if given."""
+    if data_root is None:
+        data_root = get_data_root()  # Fall back to default resolution
 
-    Parameters
-    ----------
-    cli_override : str | None
-        If provided, this path takes highest precedence.
-
-    Returns
-    -------
-    Path
-        Path to the nzcvm_registry.yaml file.
-
-
-    """
-    return get_data_root(cli_override=cli_override) / "nzcvm_registry.yaml"
+    return data_root / "nzcvm_registry.yaml"
 
 
 class VelocityTypes(Enum):

--- a/velocity_modelling/data_helper.py
+++ b/velocity_modelling/data_helper.py
@@ -279,7 +279,7 @@ def ensure(
         _run(["git", "-C", str(path), "lfs", "install"])
         if not quiet:
             typer.echo(f"[{APP_NAME}] fetching LFS objects...")
-        _run(["git", "-C", str(path), "lfs", "pull"])  # Remove the return value check
+        _run(["git", "-C", str(path), "lfs", "pull"])
 
     # Verify a key file exists
     if not (path / "nzcvm_registry.yaml").exists():

--- a/velocity_modelling/data_helper.py
+++ b/velocity_modelling/data_helper.py
@@ -279,9 +279,7 @@ def ensure(
         _run(["git", "-C", str(path), "lfs", "install"])
         if not quiet:
             typer.echo(f"[{APP_NAME}] fetching LFS objects...")
-        if _run(["git", "-C", str(path), "lfs", "pull"]) != 0:
-            typer.echo(f"[{APP_NAME}] git lfs pull failed", err=True)
-            raise typer.Exit(code=1)
+        _run(["git", "-C", str(path), "lfs", "pull"])  # Remove the return value check
 
     # Verify a key file exists
     if not (path / "nzcvm_registry.yaml").exists():

--- a/velocity_modelling/data_helper.py
+++ b/velocity_modelling/data_helper.py
@@ -207,7 +207,10 @@ def ensure(
     # If full dataset requested, require git-lfs *before* doing any clone/pull work.
 
     if full:
-        _require_bin("git-lfs","git-lfs is required for full dataset. Install git-lfs (See https://git-lfs.com) and try again.")
+        _require_bin(
+            "git-lfs",
+            "git-lfs is required for full dataset. Install git-lfs (See https://git-lfs.com) and try again.",
+        )
 
     if not quiet:
         typer.echo(f"[{APP_NAME}] target: {path}")

--- a/velocity_modelling/model_versions/2p07.yaml
+++ b/velocity_modelling/model_versions/2p07.yaml
@@ -9,8 +9,6 @@ tomography:
     GTL: true
 
 basin_edge_smoothing: true
-
-
 basins:
   - Canterbury_v19p1
   - NorthCanterbury_v19p1

--- a/velocity_modelling/model_versions/2p09.yaml
+++ b/velocity_modelling/model_versions/2p09.yaml
@@ -50,7 +50,7 @@ basins:
   - TolagaBay_v25p5
   - Waiapu_v25p5
   - WestCoast_v25p5
-  - Westport_v25p5
+  - Westport_v25p9
   - QueenCharlotte_v25p8
   - CastleHill_v25p8
   - Whakatane_v25p8

--- a/velocity_modelling/model_versions/2p09.yaml
+++ b/velocity_modelling/model_versions/2p09.yaml
@@ -17,7 +17,7 @@ basins:
   - Cheviot_v19p1
   - Hanmer_v25p3
   - Marlborough_v19p1
-  - Nelson_v25p5
+  - Nelson_v25p9
   - Wellington_v25p5
   - WaikatoHauraki_v19p7
   - Wanaka_v20p6

--- a/velocity_modelling/scripts/generate_3d_model.py
+++ b/velocity_modelling/scripts/generate_3d_model.py
@@ -931,8 +931,13 @@ def _generate_velocity_model_impl(
             nzcvm_cfg_path, out_dir, nzcvm_data_root, model_version
         )
 
-        # Set up data root and registry
-        data_root = nzcvm_data_root or get_data_root()
+        if nzcvm_data_root is not None:
+            data_root = nzcvm_data_root
+            logger.log(logging.INFO, f"Using CLI-specified data root: {data_root}")
+        else:
+            data_root = get_data_root()
+            logger.log(logging.INFO, f"Using default data root: {data_root}")
+
         if nzcvm_registry is None:
             from velocity_modelling.constants import get_registry_path
 

--- a/velocity_modelling/scripts/generate_3d_model.py
+++ b/velocity_modelling/scripts/generate_3d_model.py
@@ -497,6 +497,7 @@ def generate_3d_model(
                 basin_data_list,
                 logger,
                 smooth_bound=nz_tomography_data.smooth_boundary,
+                np_workers=np_workers,
             )
         )
     except Exception as e:

--- a/velocity_modelling/scripts/generate_3d_model.py
+++ b/velocity_modelling/scripts/generate_3d_model.py
@@ -194,8 +194,7 @@ def _h5_writer_proc(q, out_dir_str, vm_params, log_level):
     # Import your existing HDF5 writer (same one serial runs use)
     h5_writer = importlib.import_module("velocity_modelling.write.hdf5")
     write_global_qualities = h5_writer.write_global_qualities
-    # cache closer (public or private, whichever you exposed)
-    close_cache = getattr(h5_writer, "close_cache", None) or getattr(h5_writer, "_close_cache")
+    close_cache = getattr(h5_writer, "close_cache", None)
 
     # Consume items in any order; the writer module handles file layout & metadata
     while True:

--- a/velocity_modelling/scripts/generate_3d_model.py
+++ b/velocity_modelling/scripts/generate_3d_model.py
@@ -129,7 +129,7 @@ def parse_nzcvm_config(config_path: Path, logger: Logger | None = None) -> dict:
     FileNotFoundError
         If the config file cannot be found.
     ValueError
-        If a numeric value is expected but not provided, or if parsing fails.
+        If a numeric value is expected but not provided, if parsing fails.
     KeyError
         If an invalid TOPO_TYPE is specified.
     """
@@ -197,6 +197,7 @@ def parse_nzcvm_config(config_path: Path, logger: Logger | None = None) -> dict:
             (vm_params["extent_zmax"] - vm_params["extent_zmin"]) / vm_params["h_depth"]
             + 0.5
         )
+
     except FileNotFoundError:
         logger.log(logging.ERROR, f"Config file {config_path} not found")
         raise FileNotFoundError(f"Config file {config_path} not found")
@@ -1107,9 +1108,7 @@ def generate_3d_model(
         ),
     ] = None,
     smoothing: bool = False,  # placeholder for smoothing, not implemented yet
-    np_workers: Annotated[
-        int, typer.Option("--np", help="Number of parallel workers")
-    ] = 1,
+    np_workers: Annotated[int, typer.Option("--np")] = 1,
     blas_threads: int | None = None,
     log_level: str = "INFO",
 ) -> None:

--- a/velocity_modelling/scripts/generate_3d_model.py
+++ b/velocity_modelling/scripts/generate_3d_model.py
@@ -882,14 +882,6 @@ def _generate_velocity_model_impl(
         Logging level
     """
 
-    print("=== IMPL ENTRY DEBUG ===")
-    print(f"IMPL nzcvm_data_root = {nzcvm_data_root}")
-    print(f"IMPL nzcvm_data_root type = {type(nzcvm_data_root)}")
-    print(f"IMPL nzcvm_data_root is None = {nzcvm_data_root is None}")
-    if nzcvm_data_root is not None:
-        print(f"IMPL nzcvm_data_root exists = {nzcvm_data_root.exists()}")
-    print("========================")
-
     # Configure logging
     logger.setLevel(getattr(logging, log_level.upper()))
     start_time = time.time()
@@ -1163,14 +1155,6 @@ def generate_3d_model(
     HDF5 output with specific model version and BLAS threading:
         nzcvm generate-3d-model config.cfg --output-format HDF5 --model-version 2.07 --blas-threads 2
     """
-
-    print("=== CLI ENTRY DEBUG ===")
-    print(f"CLI nzcvm_data_root = {nzcvm_data_root}")
-    print(f"CLI nzcvm_data_root type = {type(nzcvm_data_root)}")
-    print(f"CLI nzcvm_data_root is None = {nzcvm_data_root is None}")
-    if nzcvm_data_root is not None:
-        print(f"CLI nzcvm_data_root exists = {nzcvm_data_root.exists()}")
-    print("======================")
 
     try:
         _generate_velocity_model_impl(

--- a/velocity_modelling/scripts/generate_3d_model.py
+++ b/velocity_modelling/scripts/generate_3d_model.py
@@ -950,8 +950,7 @@ def _generate_velocity_model_impl(
 
         if nzcvm_registry is None:
             from velocity_modelling.constants import get_registry_path
-
-            registry_path = get_registry_path()
+            registry_path = get_registry_path(data_root=data_root)
         else:
             registry_path = nzcvm_registry
 
@@ -966,6 +965,9 @@ def _generate_velocity_model_impl(
             registry_path=registry_path,
             logger=logger,
         )
+
+        # Add this right after the CVMRegistry initialization:
+        logger.log(logging.INFO, f"After CVMRegistry init, data_root still = {data_root}")
 
         # Setup mesh and model data
         logger.log(logging.INFO, "Generating global mesh")

--- a/velocity_modelling/scripts/generate_3d_model.py
+++ b/velocity_modelling/scripts/generate_3d_model.py
@@ -882,14 +882,13 @@ def _generate_velocity_model_impl(
         Logging level
     """
 
-    print(f"=== IMPL ENTRY DEBUG ===")
+    print("=== IMPL ENTRY DEBUG ===")
     print(f"IMPL nzcvm_data_root = {nzcvm_data_root}")
     print(f"IMPL nzcvm_data_root type = {type(nzcvm_data_root)}")
     print(f"IMPL nzcvm_data_root is None = {nzcvm_data_root is None}")
     if nzcvm_data_root is not None:
         print(f"IMPL nzcvm_data_root exists = {nzcvm_data_root.exists()}")
     print("========================")
-
 
     # Configure logging
     logger.setLevel(getattr(logging, log_level.upper()))
@@ -918,7 +917,9 @@ def _generate_velocity_model_impl(
     else:
         # Process + BLAS budgeting with core limit enforcement
         cores = os.cpu_count() or 2
-        actual_workers = min(np_workers, cores)  # This limits np_workers to available cores
+        actual_workers = min(
+            np_workers, cores
+        )  # This limits np_workers to available cores
         actual_blas_threads = blas_threads or max(1, cores // actual_workers)
 
         # Warn user if they requested more workers than available cores
@@ -950,6 +951,7 @@ def _generate_velocity_model_impl(
 
         if nzcvm_registry is None:
             from velocity_modelling.constants import get_registry_path
+
             registry_path = get_registry_path(data_root=data_root)
         else:
             registry_path = nzcvm_registry
@@ -967,7 +969,9 @@ def _generate_velocity_model_impl(
         )
 
         # Add this right after the CVMRegistry initialization:
-        logger.log(logging.INFO, f"After CVMRegistry init, data_root still = {data_root}")
+        logger.log(
+            logging.INFO, f"After CVMRegistry init, data_root still = {data_root}"
+        )
 
         # Setup mesh and model data
         logger.log(logging.INFO, "Generating global mesh")
@@ -1111,7 +1115,9 @@ def generate_3d_model(
         ),
     ] = None,
     smoothing: bool = False,  # placeholder for smoothing, not implemented yet
-    np_workers: Annotated[int, typer.Option("--np", help="Number of parallel workers")] = 1,
+    np_workers: Annotated[
+        int, typer.Option("--np", help="Number of parallel workers")
+    ] = 1,
     blas_threads: int | None = None,
     log_level: str = "INFO",
 ) -> None:
@@ -1158,7 +1164,7 @@ def generate_3d_model(
         nzcvm generate-3d-model config.cfg --output-format HDF5 --model-version 2.07 --blas-threads 2
     """
 
-    print(f"=== CLI ENTRY DEBUG ===")
+    print("=== CLI ENTRY DEBUG ===")
     print(f"CLI nzcvm_data_root = {nzcvm_data_root}")
     print(f"CLI nzcvm_data_root type = {type(nzcvm_data_root)}")
     print(f"CLI nzcvm_data_root is None = {nzcvm_data_root is None}")

--- a/velocity_modelling/scripts/generate_3d_model.py
+++ b/velocity_modelling/scripts/generate_3d_model.py
@@ -881,6 +881,16 @@ def _generate_velocity_model_impl(
     log_level : str
         Logging level
     """
+
+    print(f"=== IMPL ENTRY DEBUG ===")
+    print(f"IMPL nzcvm_data_root = {nzcvm_data_root}")
+    print(f"IMPL nzcvm_data_root type = {type(nzcvm_data_root)}")
+    print(f"IMPL nzcvm_data_root is None = {nzcvm_data_root is None}")
+    if nzcvm_data_root is not None:
+        print(f"IMPL nzcvm_data_root exists = {nzcvm_data_root.exists()}")
+    print("========================")
+
+
     # Configure logging
     logger.setLevel(getattr(logging, log_level.upper()))
     start_time = time.time()
@@ -1145,6 +1155,15 @@ def generate_3d_model(
     HDF5 output with specific model version and BLAS threading:
         nzcvm generate-3d-model config.cfg --output-format HDF5 --model-version 2.07 --blas-threads 2
     """
+
+    print(f"=== CLI ENTRY DEBUG ===")
+    print(f"CLI nzcvm_data_root = {nzcvm_data_root}")
+    print(f"CLI nzcvm_data_root type = {type(nzcvm_data_root)}")
+    print(f"CLI nzcvm_data_root is None = {nzcvm_data_root is None}")
+    if nzcvm_data_root is not None:
+        print(f"CLI nzcvm_data_root exists = {nzcvm_data_root.exists()}")
+    print("======================")
+
     try:
         _generate_velocity_model_impl(
             nzcvm_cfg_path=nzcvm_cfg_path,

--- a/velocity_modelling/scripts/generate_3d_model.py
+++ b/velocity_modelling/scripts/generate_3d_model.py
@@ -12,27 +12,27 @@ pip install -e  .
 
 # Execution
     # Basic usage: to use everything defined in nzcvm.cfg
-    nzcvm generate-velocity-model /path/to/nzcvm.cfg
+    nzcvm generate-3d-model /path/to/nzcvm.cfg
 
     # To override output directory
-    nzcvm generate-velocity-model /path/to/nzcvm.cfg --out-dir /path/to/output_dir
+    nzcvm generate-3d-model /path/to/nzcvm.cfg --out-dir /path/to/output_dir
 
     # To override DATA_ROOT directory
-    nzcvm generate-velocity-model /path/to/nzcvm.cfg --data-root /custom/data/path
+    nzcvm generate-3d-model /path/to/nzcvm.cfg --data-root /custom/data/path
 
     # To override "MODEL_VERSION" in nzcvm.cfg to use a .yaml file for a custom model version.
     # Requires a .yaml file with the model version under the "model_versions" directory. (eg. 2p07.yaml for model version 2.07)
-    nzcvm generate-velocity-model /path/to/nzcvm.cfg --model-version 2.07
+    nzcvm generate-3d-model /path/to/nzcvm.cfg --model-version 2.07
 
     # With custom registry location:
-    nzcvm generate-velocity-model /path/to/nzcvm.cfg --nzcvm-registry /path/to/registry.yaml
+    nzcvm generate-3d-model /path/to/nzcvm.cfg --nzcvm-registry /path/to/registry.yaml
 
     # With specific log level:
-    nzcvm generate-velocity-model /path/to/nzcvm.cfg --log-level DEBUG
+    nzcvm generate-3d-model /path/to/nzcvm.cfg --log-level DEBUG
 
     # With specific output format:
-    nzcvm generate-velocity-model /path/to/nzcvm.cfg --output-format CSV  (default: EMOD3D)
-    nzcvm generate-velocity-model /path/to/nzcvm.cfg --output-format HDF5
+    nzcvm generate-3d-model /path/to/nzcvm.cfg --output-format CSV  (default: EMOD3D)
+    nzcvm generate-3d-model /path/to/nzcvm.cfg --output-format HDF5
 
     [example] nzcvm.cfg
     CALL_TYPE=GENERATE_VELOCITY_MOD
@@ -50,17 +50,17 @@ pip install -e  .
     TOPO_TYPE=BULLDOZED
     OUTPUT_DIR=/tmp
 """
-from concurrent.futures import ProcessPoolExecutor,  as_completed
+import os
 import multiprocessing as mp
 import logging
 import sys
 import time
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from logging import Logger
-import numpy as np
-from numpy import asarray
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Optional, Tuple
 
+import numpy as np
 import typer
 from tqdm import tqdm
 
@@ -84,17 +84,6 @@ from velocity_modelling.global_model import PartialGlobalSurfaceDepths
 from velocity_modelling.registry import CVMRegistry
 from velocity_modelling.velocity3d import PartialGlobalQualities, QualitiesVector
 
-from threadpoolctl import threadpool_limits
-import threadpoolctl
-
-### for _compute_and_write_slice() workers
-from velocity_modelling.velocity3d import PartialGlobalQualities, QualitiesVector
-from velocity_modelling.global_model import PartialGlobalSurfaceDepths
-from velocity_modelling.basin_model import PartialBasinSurfaceDepths, InBasin
-from velocity_modelling.geometry import MeshVector
-
-import os
-
 # Configure logging at the module level
 logging.basicConfig(
     level=logging.INFO,
@@ -106,576 +95,9 @@ logger = logging.getLogger("nzcvm")
 app = typer.Typer(pretty_exceptions_enable=False)
 
 
-import os
-
-# Worker-visible globals, set once in the parent
-_CVM = None
-_DATA = None           # (vm1d_data, nz_tomo, global_surfaces, basin_data_list)
-_GLOBALS = None        # (global_mesh, in_basin_mesh, partial_global_mesh_list)
-_WRITER = None
-_VM_PARAMS = None
-_OUT_QUEUE = None  # set in parent when we start the writer process
-
-
-def _init_worker_queue_and_blas(q, blas_threads: int):
-    """Runs once in each worker process."""
-    import os
-    global _OUT_QUEUE
-    _OUT_QUEUE = q
-
-    # Bullet-proof BLAS cap inside the worker
-    try:
-        from threadpoolctl import threadpool_limits, threadpool_info
-        threadpool_limits(limits=blas_threads)
-        #print("threadpools in worker:", threadpool_info())
-
-    except Exception:
-        # Fallback via env if threadpoolctl isn't present
-        os.environ["OPENBLAS_NUM_THREADS"] = str(blas_threads)
-        os.environ["OMP_NUM_THREADS"] = str(blas_threads)
-        os.environ["OMP_DYNAMIC"] = "FALSE"
-
-
-
-def _compute_and_write_block(j_block, out_dir):
-    for j in j_block:
-        _compute_and_write_slice(j, out_dir)  # your existing per-slice code
-    return j_block.start  # anything; just to surface exceptions
-
-def _compute_and_write_slice(j: int, out_dir: str):
-
-    if any(x is None for x in (_CVM, _DATA, _GLOBALS, _VM_PARAMS, _WRITER)):
-        raise RuntimeError("Worker globals not initialized; ensure 'fork' is used.")
-
-
-    cvm_registry = _CVM
-    vm1d_data, nz_tomography_data, global_surfaces, basin_data_list = _DATA
-    global_mesh, in_basin_mesh, partial_global_mesh_list = _GLOBALS
-
-    pgm = partial_global_mesh_list[j]
-    pgq = PartialGlobalQualities(pgm.nx, pgm.nz)
-
-    for k in range(len(pgm.x)):
-        pg_sd = PartialGlobalSurfaceDepths(len(global_surfaces))
-        pb_sd_list = [PartialBasinSurfaceDepths(b) for b in basin_data_list]
-        qv = QualitiesVector(pgm.nz)
-
-        basin_indices = in_basin_mesh.get_basin_membership(k, j)
-        in_basin_list = [InBasin(b, len(global_mesh.z)) for b in basin_data_list]
-        for bi in basin_indices:
-            if bi >= 0:
-                in_basin_list[bi].in_basin_lat_lon = True
-
-        mv = MeshVector(pgm, k)
-        qv.assign_qualities(cvm_registry, vm1d_data, nz_tomography_data,
-                            global_surfaces, basin_data_list, mv,
-                            pg_sd, pb_sd_list, in_basin_list,
-                            in_basin_mesh, _VM_PARAMS["topo_type"])
-
-        pgq.rho[k] = qv.rho
-        pgq.vp[k] = qv.vp
-        pgq.vs[k] = qv.vs
-        pgq.inbasin[k] = qv.inbasin
-
-
-    _OUT_QUEUE.put((j, pgm, pgq))  # for official HDF5 writer module
-    #_OUT_QUEUE.put((j, pgq.vp, pgq.vs, pgq.rho, pgq.inbasin))  # for custom HDF5 writer process
-    return j
-
-
-# ---- HDF5 writer process: use the official writer module ----
-def _h5_writer_proc(q, out_dir_str, vm_params, log_level):
-    import logging, importlib
-    from pathlib import Path
-
-    os.environ.setdefault("HDF5_USE_FILE_LOCKING", "FALSE")
-
-    logger = logging.getLogger("nzcvm")
-    logger.setLevel(log_level)
-    logger.log(logging.DEBUG,"[writer] started with spawn, waiting for first item…")
-
-    out_dir = Path(out_dir_str)
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    # Import your existing HDF5 writer (same one serial runs use)
-    h5_writer = importlib.import_module("velocity_modelling.write.hdf5")
-    write_global_qualities = h5_writer.write_global_qualities
-    close_cache = getattr(h5_writer, "close_cache", None)
-
-
-
-    # Consume items in any order; the writer module handles file layout & metadata
-    got_any = False
-    while True:
-        item = q.get()
-        if item is None:
-            break
-        if not got_any:
-            logger.log(logging.DEBUG, "[writer] got first item")
-            got_any = True
-        j, pgm, pgq = item
-        write_global_qualities(out_dir, pgm, pgq, j, vm_params, logger)
-
-    # All slices done: emit XDMF **once**, then close cached file cleanly
-    try:
-        h5_writer.create_xdmf_file(out_dir / "velocity_model.h5", vm_params, logging.getLogger("nzcvm"))
-    except Exception as e:
-        logging.getLogger("nzcvm").warning("create_xdmf_file failed: %s", e)
-    try:
-        close_cache(out_dir)  # closes the single open handle in this process
-    except Exception as e:
-        logging.getLogger("nzcvm").warning("close_cache failed: %s", e)
-
-def write_velo_mod_corners_text_file(
-    global_mesh: GlobalMesh, output_dir: Path | str, logger: logging.Logger
-) -> None:
-    """
-    Write velocity model corners to a text file for reference and visualization.
-
-    Records the geographic coordinates of model corners (min/max latitude and longitude)
-    for later reference and plotting.
-
-    Parameters
-    ----------
-    global_mesh : GlobalMesh
-        Object containing the global mesh data with longitude and latitude arrays.
-    output_dir : Path or str
-        Directory where the log file will be saved.
-    logger : Logger
-        Logger for reporting progress and errors.
-
-    Raises
-    ------
-    OSError
-        If the file cannot be written due to permissions or disk issues.
-    """
-    log_file_name = Path(output_dir) / "Log" / "VeloModCorners.txt"
-    log_file_name.parent.mkdir(parents=True, exist_ok=True)
-
-    nx = len(global_mesh.x)
-    ny = len(global_mesh.y)
-
-    logger.log(logging.INFO, f"Writing velocity model corners to {log_file_name}")
-    try:
-        with log_file_name.open("w") as fp:
-            fp.write(">Velocity model corners.\n")
-            fp.write(">Lon\tLat\n")
-            fp.write(f"{global_mesh.lon[0][ny - 1]}\t{global_mesh.lat[0][ny - 1]}\n")
-            fp.write(f"{global_mesh.lon[0][0]}\t{global_mesh.lat[0][0]}\n")
-            fp.write(f"{global_mesh.lon[nx - 1][0]}\t{global_mesh.lat[nx - 1][0]}\n")
-            fp.write(
-                f"{global_mesh.lon[nx - 1][ny - 1]}\t{global_mesh.lat[nx - 1][ny - 1]}\n"
-            )
-        logger.log(logging.INFO, "Velocity model corners file write complete.")
-    except OSError as e:
-        logger.log(logging.ERROR, f"Failed to write velocity model corners: {e}")
-        raise OSError(
-            f"Failed to write velocity model corners to {log_file_name}: {str(e)}"
-        )
-
-
-@cli.from_docstring(app)
-def generate_3d_model(
-    nzcvm_cfg_path: Annotated[Path, typer.Argument(exists=True, dir_okay=False)],
-    out_dir: Annotated[Path | None, typer.Option(file_okay=False)] = None,
-    nzcvm_registry: Annotated[
-        Path | None,
-        typer.Option(
-            exists=False,
-            dir_okay=False,
-            help="Path to nzcvm_registry.yaml (default: nzcvm_data/nzcvm_registry.yaml",
-        ),
-    ] = None,
-    model_version: Annotated[str | None, typer.Option()] = None,
-    output_format: Annotated[str, typer.Option()] = WriteFormat.EMOD3D.name,
-    nzcvm_data_root: Annotated[
-        Path | None,
-        typer.Option(
-            file_okay=False,
-            exists=False,  # will validate later
-            help="Override the default nzcvm_data directory",
-        ),
-    ] = None,
-    smoothing: Annotated[
-        bool, typer.Option()
-    ] = False,  # placeholder for smoothing, not implemented yet
-    np_workers: Annotated[
-        int | None, typer.Option("--np")] = None,
-    blas_threads: Annotated[
-        int | None, typer.Option()] = None,
-
-        log_level: Annotated[str, typer.Option()] = "INFO",
-) -> None:
-    """
-    Generate a 3D velocity model and write it to disk.
-
-    This is the main function that orchestrates the velocity model generation process:
-    1. Creates the model mesh grid
-    2. Loads all required datasets (global models, tomography, basins)
-    3. Processes each latitude slice and populates velocity/density values
-    4. Writes results to disk in the specified format
-
-    The data root resolution order is:
-      1) --nzcvm-data-root (this option)
-      2) NZCVM_DATA_ROOT env var
-      3) ~/.config/nzcvm_data/config.json (written by `nzcvm-data install`)
-      4) sensible defaults
-
-    Parameters
-    ----------
-    nzcvm_cfg_path : Path
-        Path to the nzcvm.cfg configuration file.
-    out_dir : Path, optional
-        Path to the output directory where the velocity model files will be written (overrides OUTPUT_DIR in config file).
-        If not provided, the directory specified in the config file will be used.
-    nzcvm_registry : Path, optional
-        Path to the model registry file (default: nzcvm_data/nzcvm_registry.yaml).
-    model_version : str, optional
-        Version of the model to use (overrides MODEL_VERSION in config file).
-        If not provided, the version from the config file will be used.
-    output_format : str, optional
-        Format to write the output. Options: "EMOD3D", "CSV", "HDF5" (default: "EMOD3D").
-    nzcvm_data_root : Path, optional
-        Override the default nzcvm_data directory.
-    smoothing : bool, optional
-        Unsupported option for future smoothing implementation at model boundaries (default: False).
-    np_workers : int, optional
-        Number of worker processes to use for parallel processing (default: 1 = serial).
-
-    blas_threads : int, optional
-        Number of BLAS threads per worker process (default: auto).
-    log_level : str, optional
-        Logging level for the script (default: "INFO").
-
-    Raises
-    ------
-    ValueError
-        If the config file is invalid, the output format is unsupported, or CALL_TYPE is incorrect.
-    OSError
-        If there are issues writing to the output directory or files.
-    RuntimeError
-        If an error occurs during model generation or data processing.
-    """
-    start_time = time.time()
-
-    # Configure logging
-    numeric_level = getattr(logging, log_level.upper(), logging.INFO)
-    logger.setLevel(numeric_level)
-
-    logger.log(logging.DEBUG, f"Logger initialized with level {log_level}")
-    logger.log(logging.INFO, "Beginning velocity model generation")
-
-    # Resolve data root path, giving precedence to the CLI argument
-    try:
-        data_root = get_data_root(
-            cli_override=str(nzcvm_data_root) if nzcvm_data_root else None
-        )
-        logger.log(logging.INFO, f"Using NZCVM data root : {data_root}")
-    except FileNotFoundError as e:
-        logger.log(logging.ERROR, str(e))
-        raise
-
-    # Resolve registry path
-    if nzcvm_registry:
-        registry_path = nzcvm_registry.expanduser().resolve()
-    else:
-        registry_path = data_root / "nzcvm_registry.yaml"
-
-    # Validate registry path
-    if not registry_path.exists():
-        msg = f"NZCVM registry file not found: {registry_path}"
-        logger.log(logging.ERROR, msg)
-        raise FileNotFoundError(msg)
-    logger.log(logging.INFO, f"Using registry: {registry_path}")
-
-    # Parse the config file
-    try:
-        vm_params = parse_nzcvm_config(nzcvm_cfg_path, logger)
-        if vm_params.get("call_type") != "GENERATE_VELOCITY_MOD":
-            logger.log(
-                logging.ERROR, f"Unsupported CALL_TYPE: {vm_params.get('call_type')}"
-            )
-            raise ValueError(f"Unsupported CALL_TYPE: {vm_params.get('call_type')}")
-    except Exception as e:
-        if isinstance(e, (SystemExit, KeyboardInterrupt)):
-            raise  # Re-raise critical exceptions
-        logger.log(logging.ERROR, f"Failed to parse config file: {e}")
-        raise ValueError(f"Failed to parse config file {nzcvm_cfg_path}: {str(e)}")
-
-    # If out_dir is not provided, use output_dir from vm_params if available
-    if out_dir is None:
-        if "output_dir" in vm_params:
-            out_dir = Path(vm_params["output_dir"])
-            logger.log(logging.INFO, f"Using output_dir from config: {out_dir}")
-        else:
-            logger.log(logging.ERROR, "No output directory specified")
-            raise ValueError("No output directory specified in config or command line")
-
-    logger.log(logging.INFO, f"Output directory set to {out_dir}")
-
-    # Use --model-version if provided, otherwise fall back to MODEL_VERSION from config
-    if model_version and model_version != vm_params.get("model_version"):
-        logger.log(
-            logging.INFO,
-            f"Updating model_version from {vm_params['model_version']} to {model_version}",
-        )
-        vm_params["model_version"] = model_version
-    else:
-        logger.log(logging.INFO, f"Using model version: {vm_params['model_version']}")
-
-    # Validate and import the appropriate writer based on format
-    try:
-        _ = WriteFormat[output_format.upper()]
-    except KeyError:
-        logger.log(logging.ERROR, f"Unsupported output format: {output_format}")
-        raise ValueError(f"Unsupported output format: {output_format}")
-
-    if np_workers and np_workers > 1 and output_format.upper() != "HDF5":
-        logger.info("np>1 requested → forcing output_format=HDF5 for safe parallel writes.")
-        output_format = "HDF5"
-
-    import importlib
-
-    try:
-        module_name = f"velocity_modelling.write.{output_format.lower()}"
-        writer_module = importlib.import_module(module_name)
-        write_global_qualities = writer_module.write_global_qualities
-        logger.log(logging.DEBUG, f"Using {output_format} writer module")
-    except ImportError as e:
-        logger.log(
-            logging.ERROR, f"Failed to import writer module for {output_format}: {e}"
-        )
-        raise ValueError(f"Unsupported output format: {output_format}")
-
-    # Ensure output directory exists
-    out_dir = out_dir.resolve()
-    try:
-        out_dir.mkdir(exist_ok=True, parents=True)
-    except OSError as e:
-        logger.log(logging.ERROR, f"Failed to create output directory {out_dir}: {e}")
-        raise OSError(f"Failed to create output directory {out_dir}: {str(e)}")
-
-
-    if output_format == "HDF5":
-        h5_path = (out_dir / "velocity_model.h5").resolve()
-        # Pre-create empty file so writer opens with "r+"
-        import h5py
-        with h5py.File(h5_path, "w") as _:
-            pass
-
-    # Initialize registry and generate model
-    cvm_registry = CVMRegistry(
-        vm_params["model_version"], data_root, nzcvm_registry, logger
-    )
-
-    # Create model grid
-    logger.log(logging.INFO, "Generating model grid")
-    global_mesh = gen_full_model_grid_great_circle(vm_params, logger)
-
-    write_velo_mod_corners_text_file(global_mesh, out_dir, logger)
-
-    # Load all required data
-    logger.log(logging.INFO, "Loading model data")
-
-    try:
-        vm1d_data, nz_tomography_data, global_surfaces, basin_data_list = (
-            cvm_registry.load_all_global_data()
-        )
-    except Exception as e:
-        if isinstance(e, (SystemExit, KeyboardInterrupt)):
-            raise  # Re-raise critical exceptions
-        logger.log(logging.ERROR, f"Failed to load model data: {e}")
-        raise RuntimeError(f"Failed to load model data: {str(e)}")
-
-    # Preprocess basin membership for efficiency
-    logger.log(logging.INFO, "Pre-processing basin membership")
-
-    try:
-        in_basin_mesh, partial_global_mesh_list = (
-            InBasinGlobalMesh.preprocess_basin_membership(
-                global_mesh,
-                basin_data_list,
-                logger,
-                smooth_bound=nz_tomography_data.smooth_boundary,
-                np_workers=np_workers,
-            )
-        )
-    except Exception as e:
-        if isinstance(e, (SystemExit, KeyboardInterrupt)):
-            raise  # Re-raise critical exceptions
-        logger.log(logging.ERROR, f"Error preprocessing basin membership: {e}")
-        raise RuntimeError(f"Error preprocessing basin membership: {str(e)}")
-
-
-    global _CVM, _DATA, _GLOBALS, _WRITER, _VM_PARAMS
-    # Expose to workers (inherited on fork)
-    _CVM = cvm_registry
-    _DATA = (vm1d_data, nz_tomography_data, global_surfaces, basin_data_list)
-    _GLOBALS = (global_mesh, in_basin_mesh, partial_global_mesh_list)
-    _WRITER = write_global_qualities
-    _VM_PARAMS = vm_params
-
-    slices_tmp = out_dir / "slices_tmp"
-    slices_tmp.mkdir(parents=True, exist_ok=True)
-
-    # Process each latitude slice (serial by default; threaded if --np > 1)
-    # Process each latitude slice
-    total_slices = len(global_mesh.y)
-
-    if not np_workers or np_workers <= 1:
-        # serial (unchanged)
-        for j in tqdm(range(total_slices), desc="Generating velocity model", unit="slice"):
-            partial_global_mesh = partial_global_mesh_list[j]
-            partial_global_qualities = PartialGlobalQualities(
-                partial_global_mesh.nx, partial_global_mesh.nz
-            )
-
-            for k in range(len(partial_global_mesh.x)):
-                partial_global_surface_depths = PartialGlobalSurfaceDepths(
-                    len(global_surfaces)
-                )
-                partial_basin_surface_depths_list = [
-                    PartialBasinSurfaceDepths(basin_data) for basin_data in basin_data_list
-                ]
-                qualities_vector = QualitiesVector(partial_global_mesh.nz)
-
-                basin_indices = in_basin_mesh.get_basin_membership(k, j)
-                in_basin_list = [
-                    InBasin(basin_data, len(global_mesh.z))
-                    for basin_data in basin_data_list
-                ]
-                for basin_idx in basin_indices:
-                    if basin_idx >= 0:
-                        in_basin_list[basin_idx].in_basin_lat_lon = True
-
-                if smoothing:
-                    logger.log(
-                        logging.DEBUG, "Smoothing option selected but not implemented"
-                    )
-                    # Placeholder for future implementation
-                else:
-                    try:
-                        mesh_vector = MeshVector(partial_global_mesh, k)
-                        qualities_vector.assign_qualities(
-                            cvm_registry,
-                            vm1d_data,
-                            nz_tomography_data,
-                            global_surfaces,
-                            basin_data_list,
-                            mesh_vector,
-                            partial_global_surface_depths,
-                            partial_basin_surface_depths_list,
-                            in_basin_list,
-                            in_basin_mesh,
-                            vm_params["topo_type"],
-                        )
-                        partial_global_qualities.rho[k] = qualities_vector.rho
-                        partial_global_qualities.vp[k] = qualities_vector.vp
-                        partial_global_qualities.vs[k] = qualities_vector.vs
-                        partial_global_qualities.inbasin[k] = qualities_vector.inbasin
-                    except AttributeError as e:
-                        logger.log(
-                            logging.ERROR,
-                            f"Error accessing qualities vector attributes at j={j}, k={k}: {e}",
-                        )
-                        raise RuntimeError(
-                            f"Error processing point at j={j}, k={k}: {str(e)}"
-                        )
-                    except Exception as e:
-                        if isinstance(e, (SystemExit, KeyboardInterrupt)):
-                            raise  # Re-raise critical exceptions
-                        logger.log(
-                            logging.ERROR, f"Error processing point at j={j}, k={k}: {e}"
-                        )
-                        raise RuntimeError(
-                            f"Error processing point at j={j}, k={k}: {str(e)}"
-                        )
-
-            # Write this latitude slice to disk
-            try:
-                # Use a single function call format for all writer modules
-                write_global_qualities(
-                    out_dir,
-                    partial_global_mesh,
-                    partial_global_qualities,
-                    j,
-                    vm_params,
-                    logger,
-                )
-            except Exception as e:
-                if isinstance(e, (SystemExit, KeyboardInterrupt)):
-                    raise  # Re-raise critical exceptions
-                logger.log(logging.ERROR, f"Error writing slice j={j}: {e}")
-                raise OSError(f"Failed to write slice j={j} to {out_dir}: {str(e)}")
-    else:
-        # processes + BLAS budgeting
-        cores = os.cpu_count() or 2
-        W = min(np_workers, cores)
-        T = blas_threads or max(1, cores // W)
-
-        BLOCK = 4
-        blocks = [range(s, min(s + BLOCK, total_slices)) for s in range(0, total_slices, BLOCK)]
-
-        # Use fork so workers inherit _CVM/_DATA/_GLOBALS without pickling
-        ctx = mp.get_context("fork")  # IMPORTANT: fork to inherit globals
-
-
-        # compute pool
-        fork_ctx = mp.get_context("fork")
-        logger.info(f"[mp] using context: {fork_ctx.get_start_method()}")
-
-        # writer process (spawned cleanly for HDF5)
-        spawn_ctx = mp.get_context("spawn")
-        logger.info(f"[mp] using context: {spawn_ctx.get_start_method()}")
-
-        parallel_setup_start_time = time.time()
-
-        ny, nx, nz = len(global_mesh.y), len(global_mesh.x), len(global_mesh.z)
-
-
-        # 1) start writer
-        # --- use the WRITER's context for the queue ---
-        _OUT_QUEUE = spawn_ctx.Queue(maxsize=64)  # small bounded queue is enough
-
-        writer = spawn_ctx.Process(
-            target=_h5_writer_proc,
-            args=(_OUT_QUEUE, out_dir, vm_params, logger.level), # use this line to use the official writer module
-            daemon=True,
-        )
-        writer.start()
-
-        # 2) launch compute processes (each enqueue slices)
-        with ProcessPoolExecutor(max_workers=W, mp_context=fork_ctx, initializer=_init_worker_queue_and_blas, initargs=(_OUT_QUEUE,T),) as ex:
-            #futures = [ex.submit(_compute_and_write_slice, j, str(out_dir)) for j in range(total_slices)]
-            # for f in tqdm(as_completed(futures), total=total_slices,
-            #               desc="Generating velocity model", unit="slice"):
-            #     f.result()
-            futures = [ex.submit(_compute_and_write_block, jb, str(out_dir)) for jb in blocks]
-            for i, _ in enumerate(tqdm(as_completed(futures), total=len(blocks), desc="Generating velocity model", unit="block")):
-                _.result()
-                if i==0:
-                    parallel_setup_elapsed_time = time.time() - parallel_setup_start_time
-                    logger.log(
-                        logging.INFO,
-                        f"Getting ready for parallel computation in {parallel_setup_elapsed_time:.2f} seconds",
-                    )
-
-        # 3) tell writer to finish and wait
-        _OUT_QUEUE.put(None)  # sentinel
-        writer.join()
-
-    logger.log(logging.INFO, "Generation of velocity model 100% complete")
-    logger.log(
-        logging.INFO,
-        f"Model (version: {vm_params['model_version']}) successfully generated and written to {out_dir}",
-    )
-    elapsed_time = time.time() - start_time
-    logger.log(
-        logging.INFO,
-        f"Velocity model generation completed in {elapsed_time:.2f} seconds",
-    )
-
-
+# ============================================================================
+# Configuration Loading Functions
+# ============================================================================
 def parse_nzcvm_config(config_path: Path, logger: Logger | None = None) -> dict:
     """
     Parse the nzcvm config file and convert it to a dictionary format.
@@ -741,7 +163,7 @@ def parse_nzcvm_config(config_path: Path, logger: Logger | None = None) -> dict:
                     try:
                         vm_params[dest_key] = TopoTypes[value]
                     except KeyError:
-                        Logger.error(f"Invalid topo type {value}")
+                        logger.error(f"Invalid topo type {value}")
                         raise KeyError(f"Invalid topo type {value}")
                 elif key in numeric_keys:
                     if float_value is None:
@@ -766,15 +188,918 @@ def parse_nzcvm_config(config_path: Path, logger: Logger | None = None) -> dict:
             + 0.5
         )
     except FileNotFoundError:
-        logger.log(logging.ERROR, "Config file {config_path} not found")
+        logger.error(f"Config file {config_path} not found")
         raise FileNotFoundError(f"Config file {config_path} not found")
+    except (ValueError, KeyError) as e:
+        logger.error(f"Error parsing config file {config_path}: {e}")
+        raise
+    except KeyboardInterrupt:
+        raise
     except Exception as e:
-        if isinstance(e, (SystemExit, KeyboardInterrupt)):
-            raise  # Re-raise critical exceptions
-        logger.log(logging.ERROR, f"Error parsing config file {config_path}: {e}")
+        logger.error(f"Error parsing config file {config_path}: {e}")
         raise ValueError(f"Error parsing config file {config_path}: {str(e)}")
 
     return vm_params
+
+def _load_vm_params_from_cfg(
+        nzcvm_cfg_path: Path,
+        out_dir: Optional[Path] = None,
+        nzcvm_data_root: Optional[Path] = None,
+        model_version: Optional[str] = None,
+) -> dict:
+    """
+    Load velocity model parameters from configuration file.
+
+    Parameters
+    ----------
+    nzcvm_cfg_path : Path
+        Path to the NZCVM configuration file
+    out_dir : Path, optional
+        Override output directory
+    nzcvm_data_root : Path, optional
+        Override data root directory
+    model_version : str, optional
+        Override model version
+
+    Returns
+    -------
+    dict
+        Dictionary of velocity model parameters
+    """
+    # Parse the config file using the existing parser
+    vm_params = parse_nzcvm_config(nzcvm_cfg_path, logger)
+
+    # Check call type
+    if vm_params.get("call_type") != "GENERATE_VELOCITY_MOD":
+        raise ValueError(f"Unsupported CALL_TYPE: {vm_params.get('call_type')}")
+
+    # Apply overrides if provided
+    if out_dir is not None:
+        vm_params["output_dir"] = out_dir
+    if model_version is not None:
+        vm_params["model_version"] = model_version
+
+    # Ensure output_dir is a Path object
+    vm_params["output_dir"] = Path(vm_params["output_dir"])
+
+    return vm_params
+
+# ============================================================================
+# Common Processing Functions (shared between serial and parallel)
+# ============================================================================
+
+def _compute_point_qualities(
+        k: int,
+        j: int,
+        partial_mesh,
+        global_mesh: GlobalMesh,
+        in_basin_mesh: InBasinGlobalMesh,
+        cvm_registry: CVMRegistry,
+        vm1d_data,
+        nz_tomography_data,
+        global_surfaces: list,
+        basin_data_list: list,
+        vm_params: dict
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Compute velocity model properties for a single point (x,y) at all depths.
+
+    This function contains the core computation logic shared between serial
+    and parallel processing modes.
+
+    Parameters
+    ----------
+    k : int
+        X-coordinate index in the partial mesh
+    j : int
+        Y-coordinate index in the global mesh
+    partial_mesh : PartialGlobalMesh
+        Mesh data for the current latitude slice
+    global_mesh : GlobalMesh
+        The complete model mesh grid
+    in_basin_mesh : InBasinGlobalMesh
+        Precomputed basin membership data
+    cvm_registry : CVMRegistry
+        Registry containing model data and configurations
+    vm1d_data : object
+        1D velocity model data
+    nz_tomography_data : object
+        Tomography model data for New Zealand
+    global_surfaces : list
+        List of global surface models
+    basin_data_list : list
+        List of basin model data
+    vm_params : dict
+        Velocity model parameters
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+        Arrays of (rho, vp, vs, inbasin) for all depths at this point
+    """
+    # Initialize depth-dependent data structures
+    partial_global_surface_depths = PartialGlobalSurfaceDepths(len(global_surfaces))
+    partial_basin_surface_depths_list = [
+        PartialBasinSurfaceDepths(basin_data) for basin_data in basin_data_list
+    ]
+    qualities_vector = QualitiesVector(partial_mesh.nz)
+
+    # Determine basin membership for this point
+    basin_indices = in_basin_mesh.get_basin_membership(k, j)
+    in_basin_list = [
+        InBasin(basin_data, len(global_mesh.z)) for basin_data in basin_data_list
+    ]
+    for basin_idx in basin_indices:
+        if basin_idx >= 0:
+            in_basin_list[basin_idx].in_basin_lat_lon = True
+
+    # Compute velocity model properties at this point
+    mesh_vector = MeshVector(partial_mesh, k)
+    qualities_vector.assign_qualities(
+        cvm_registry,
+        vm1d_data,
+        nz_tomography_data,
+        global_surfaces,
+        basin_data_list,
+        mesh_vector,
+        partial_global_surface_depths,
+        partial_basin_surface_depths_list,
+        in_basin_list,
+        in_basin_mesh,
+        vm_params["topo_type"],
+    )
+
+    return (
+        qualities_vector.rho,
+        qualities_vector.vp,
+        qualities_vector.vs,
+        qualities_vector.inbasin
+    )
+
+
+def _process_single_slice(
+        j: int,
+        partial_mesh,
+        global_mesh: GlobalMesh,
+        in_basin_mesh: InBasinGlobalMesh,
+        cvm_registry: CVMRegistry,
+        vm1d_data,
+        nz_tomography_data,
+        global_surfaces: list,
+        basin_data_list: list,
+        vm_params: dict,
+        smoothing: bool = False,
+        logger: Optional[logging.Logger] = None
+) -> PartialGlobalQualities:
+    """
+    Process a single y-slice to compute velocity model properties.
+
+    This function processes one latitude slice of the velocity model, computing
+    P-wave velocity, S-wave velocity, density, and basin membership for all
+    points in the slice. Used by both serial and parallel processing modes.
+
+    Parameters
+    ----------
+    j : int
+        Y-slice index to process
+    partial_mesh : PartialGlobalMesh
+        Mesh data for this slice
+    global_mesh : GlobalMesh
+        The complete model mesh grid
+    in_basin_mesh : InBasinGlobalMesh
+        Precomputed basin membership data
+    cvm_registry : CVMRegistry
+        Registry containing model data and configurations
+    vm1d_data : object
+        1D velocity model data
+    nz_tomography_data : object
+        Tomography model data for New Zealand
+    global_surfaces : list
+        List of global surface models
+    basin_data_list : list
+        List of basin model data
+    vm_params : dict
+        Velocity model parameters
+    smoothing : bool, optional
+        Whether to apply smoothing (not yet implemented)
+    logger : logging.Logger, optional
+        Logger for error reporting
+
+    Returns
+    -------
+    PartialGlobalQualities
+        Computed velocity model properties for this slice
+    """
+    if logger is None:
+        logger = logging.getLogger("nzcvm")
+
+    partial_qualities = PartialGlobalQualities(partial_mesh.nx, partial_mesh.nz)
+
+    # Process each x-coordinate in this y-slice
+    for k in range(len(partial_mesh.x)):
+        # Apply smoothing if requested (placeholder for future implementation)
+        if smoothing:
+            logger.debug("Smoothing option selected but not implemented")
+
+        try:
+            # Compute velocity model properties for this point
+            rho, vp, vs, inbasin = _compute_point_qualities(
+                k, j, partial_mesh, global_mesh, in_basin_mesh,
+                cvm_registry, vm1d_data, nz_tomography_data,
+                global_surfaces, basin_data_list, vm_params
+            )
+
+            # Store computed properties
+            partial_qualities.rho[k] = rho
+            partial_qualities.vp[k] = vp
+            partial_qualities.vs[k] = vs
+            partial_qualities.inbasin[k] = inbasin
+
+        except AttributeError as e:
+            logger.error(f"Error accessing qualities vector attributes at j={j}, k={k}: {e}")
+            raise RuntimeError(f"Error processing point at j={j}, k={k}: {str(e)}")
+        except (ValueError, RuntimeError) as e:
+            logger.error(f"Error processing point at j={j}, k={k}: {e}")
+            raise RuntimeError(f"Error processing point at j={j}, k={k}: {str(e)}")
+        except KeyboardInterrupt:
+            raise
+        except Exception as e:
+            logger.error(f"Unexpected error processing point at j={j}, k={k}: {e}")
+            raise RuntimeError(f"Unexpected error processing point at j={j}, k={k}: {str(e)}")
+
+    return partial_qualities
+
+
+# ============================================================================
+# Serial Processing Implementation
+# ============================================================================
+
+def _run_serial_processing(
+        global_mesh: GlobalMesh,
+        in_basin_mesh: InBasinGlobalMesh,
+        partial_global_mesh_list: list,
+        cvm_registry: CVMRegistry,
+        vm1d_data,
+        nz_tomography_data,
+        global_surfaces: list,
+        basin_data_list: list,
+        vm_params: dict,
+        out_dir: Path,
+        write_global_qualities,
+        smoothing: bool,
+        logger: logging.Logger
+) -> None:
+    """
+    Execute the complete serial processing workflow.
+
+    This function handles the complete serial processing workflow, iterating
+    through each latitude slice and computing velocity model properties in
+    a single-threaded manner.
+
+    Parameters
+    ----------
+    global_mesh : GlobalMesh
+        The complete model mesh grid
+    in_basin_mesh : InBasinGlobalMesh
+        Precomputed basin membership data
+    partial_global_mesh_list : list
+        List of partial meshes for each y-slice
+    cvm_registry : CVMRegistry
+        Registry containing model data and configurations
+    vm1d_data : object
+        1D velocity model data
+    nz_tomography_data : object
+        Tomography model data for New Zealand
+    global_surfaces : list
+        List of global surface models
+    basin_data_list : list
+        List of basin model data
+    vm_params : dict
+        Velocity model parameters
+    out_dir : Path
+        Output directory for results
+    write_global_qualities : callable
+        Function to write slice data to disk
+    smoothing : bool
+        Whether to apply smoothing
+    logger : logging.Logger
+        Logger for progress reporting
+    """
+    total_slices = len(global_mesh.y)
+    logger.info(f"Starting serial processing of {total_slices} slices")
+
+    for j in tqdm(range(total_slices), desc="Generating velocity model", unit="slice"):
+        partial_mesh = partial_global_mesh_list[j]
+
+        # Process this slice
+        partial_qualities = _process_single_slice(
+            j, partial_mesh, global_mesh, in_basin_mesh,
+            cvm_registry, vm1d_data, nz_tomography_data,
+            global_surfaces, basin_data_list, vm_params,
+            smoothing, logger
+        )
+
+        # Write this latitude slice to disk
+        try:
+            write_global_qualities(
+                out_dir, partial_mesh, partial_qualities, j, vm_params, logger
+            )
+        except KeyboardInterrupt:
+            raise
+        except (OSError, IOError) as e:
+            logger.error(f"File system error writing slice {j}: {e}")
+            raise OSError(f"Failed to write slice {j}: {str(e)}")
+        except Exception as e:
+            logger.error(f"Error writing slice {j} to disk: {e}")
+            raise RuntimeError(f"Error writing slice {j}: {str(e)}")
+
+    logger.info("Serial processing completed successfully")
+
+
+# ============================================================================
+# Parallel Processing Implementation
+# ============================================================================
+
+# Worker-visible globals, set once in the parent process for fork context
+_CVM_REGISTRY = None
+_MODEL_DATA = None  # (vm1d_data, nz_tomo, global_surfaces, basin_data_list)
+_MESH_DATA = None  # (global_mesh, in_basin_mesh, partial_global_mesh_list)
+_VM_PARAMS = None
+_OUTPUT_QUEUE = None
+
+
+def _init_worker_process(queue, blas_threads: int) -> None:
+    """
+    Initialize worker process with output queue and BLAS thread limits.
+
+    This function runs once in each worker process to set up the output queue
+    and configure BLAS threading to prevent oversubscription.
+
+    Parameters
+    ----------
+    queue : multiprocessing.Queue
+        Queue for sending results to the writer process
+    blas_threads : int
+        Maximum number of BLAS threads per worker process
+    """
+    global _OUTPUT_QUEUE
+    _OUTPUT_QUEUE = queue
+
+    # Configure BLAS threading to prevent oversubscription
+    try:
+        from threadpoolctl import threadpool_limits
+        threadpool_limits(limits=blas_threads)
+    except ImportError:
+        # Fallback using environment variables if threadpoolctl unavailable
+        os.environ["OPENBLAS_NUM_THREADS"] = str(blas_threads)
+        os.environ["OMP_NUM_THREADS"] = str(blas_threads)
+        os.environ["OMP_DYNAMIC"] = "FALSE"
+
+
+def _compute_slice_block(slice_indices: range, use_blocks: bool = True) -> int:
+    """
+    Compute a block of y-slices and send results to the writer process.
+
+    This function processes multiple consecutive y-slices as a block to improve
+    parallel efficiency and reduce queue overhead when use_blocks is True.
+    When False, processes slices individually.
+
+    Parameters
+    ----------
+    slice_indices : range
+        Range of y-slice indices to process in this block
+    use_blocks : bool, optional
+        Whether to process as blocks or individual slices (default: True)
+
+    Returns
+    -------
+    int
+        Starting index of the processed block (for exception handling)
+
+    Raises
+    ------
+    RuntimeError
+        If worker globals are not properly initialized
+    """
+    # Verify worker globals are initialized
+    if any(x is None for x in (_CVM_REGISTRY, _MODEL_DATA, _MESH_DATA, _VM_PARAMS)):
+        raise RuntimeError("Worker globals not initialized; ensure 'fork' context is used.")
+
+    # Unpack global data once for efficiency
+    cvm_registry = _CVM_REGISTRY
+    vm1d_data, nz_tomography_data, global_surfaces, basin_data_list = _MODEL_DATA
+    global_mesh, in_basin_mesh, partial_global_mesh_list = _MESH_DATA
+
+    # Process each slice in the block
+    for j in slice_indices:
+        partial_mesh = partial_global_mesh_list[j]
+
+        # Process this slice using the common function
+        partial_qualities = _process_single_slice(
+            j, partial_mesh, global_mesh, in_basin_mesh,
+            cvm_registry, vm1d_data, nz_tomography_data,
+            global_surfaces, basin_data_list, _VM_PARAMS
+        )
+
+        # Send results to writer process
+        _OUTPUT_QUEUE.put((j, partial_mesh, partial_qualities))
+
+    return slice_indices.start
+
+
+def _setup_parallel_globals(
+        cvm_registry: CVMRegistry,
+        vm1d_data,
+        nz_tomography_data,
+        global_surfaces: list,
+        basin_data_list: list,
+        global_mesh: GlobalMesh,
+        in_basin_mesh: InBasinGlobalMesh,
+        partial_global_mesh_list: list,
+        vm_params: dict
+) -> None:
+    """
+    Set up global variables for parallel worker processes.
+
+    This function initializes the global variables that will be inherited
+    by worker processes when using the 'fork' multiprocessing context.
+
+    Parameters
+    ----------
+    cvm_registry : CVMRegistry
+        Registry containing model data and configurations
+    vm1d_data : object
+        1D velocity model data
+    nz_tomography_data : object
+        Tomography model data for New Zealand
+    global_surfaces : list
+        List of global surface models
+    basin_data_list : list
+        List of basin model data
+    global_mesh : GlobalMesh
+        The complete model mesh grid
+    in_basin_mesh : InBasinGlobalMesh
+        Precomputed basin membership data
+    partial_global_mesh_list : list
+        List of partial meshes for each y-slice
+    vm_params : dict
+        Velocity model parameters
+    """
+    global _CVM_REGISTRY, _MODEL_DATA, _MESH_DATA, _VM_PARAMS
+
+    _CVM_REGISTRY = cvm_registry
+    _MODEL_DATA = (vm1d_data, nz_tomography_data, global_surfaces, basin_data_list)
+    _MESH_DATA = (global_mesh, in_basin_mesh, partial_global_mesh_list)
+    _VM_PARAMS = vm_params
+
+
+def _create_slice_blocks(total_slices: int, num_workers: int, use_blocks: bool = True) -> list:
+    """
+    Create blocks of slice indices for parallel processing.
+
+    Parameters
+    ----------
+    total_slices : int
+        Total number of y-slices to process
+    num_workers : int
+        Number of worker processes
+    use_blocks : bool, optional
+        Whether to group slices into blocks (default: True)
+
+    Returns
+    -------
+    list
+        List of range objects representing slice blocks
+    """
+    if not use_blocks:
+        # Process individual slices
+        return [range(i, i + 1) for i in range(total_slices)]
+
+    # Group slices into blocks for better efficiency
+    slices_per_block = max(1, total_slices // (num_workers * 2))
+    blocks = []
+
+    for start in range(0, total_slices, slices_per_block):
+        end = min(start + slices_per_block, total_slices)
+        blocks.append(range(start, end))
+
+    return blocks
+
+
+def _run_parallel_processing(
+        global_mesh: GlobalMesh,
+        in_basin_mesh: InBasinGlobalMesh,
+        partial_global_mesh_list: list,
+        cvm_registry: CVMRegistry,
+        vm1d_data,
+        nz_tomography_data,
+        global_surfaces: list,
+        basin_data_list: list,
+        vm_params: dict,
+        out_dir: Path,
+        np_workers: int,
+        blas_threads: int,
+        use_blocks: bool,
+        logger: logging.Logger
+) -> None:
+    """
+    Execute the complete parallel processing workflow.
+
+    This function coordinates parallel processing using multiple worker processes
+    and a dedicated HDF5 writer process.
+
+    Parameters
+    ----------
+    global_mesh : GlobalMesh
+        The complete model mesh grid
+    in_basin_mesh : InBasinGlobalMesh
+        Precomputed basin membership data
+    partial_global_mesh_list : list
+        List of partial meshes for each y-slice
+    cvm_registry : CVMRegistry
+        Registry containing model data and configurations
+    vm1d_data : object
+        1D velocity model data
+    nz_tomography_data : object
+        Tomography model data for New Zealand
+    global_surfaces : list
+        List of global surface models
+    basin_data_list : list
+        List of basin model data
+    vm_params : dict
+        Velocity model parameters
+    out_dir : Path
+        Output directory for results
+    np_workers : int
+        Number of worker processes to use
+    blas_threads : int
+        Number of BLAS threads per worker process
+    use_blocks : bool
+        Whether to group slices into blocks for processing
+    logger : logging.Logger
+        Logger for progress reporting
+    """
+    from velocity_modelling.write.hdf5 import start_hdf5_writer_process
+
+    total_slices = len(global_mesh.y)
+
+    if use_blocks:
+        slice_blocks = _create_slice_blocks(total_slices, np_workers, use_blocks)
+        logger.info(f"Processing {total_slices} slices in {len(slice_blocks)} blocks using {np_workers} workers")
+        if len(slice_blocks) > 0:
+            avg_block_size = sum(len(block) for block in slice_blocks) / len(slice_blocks)
+            logger.info(f"Average block size: {avg_block_size:.1f} slices per block")
+    else:
+        slice_blocks = _create_slice_blocks(total_slices, np_workers, use_blocks)
+        logger.info(f"Processing {total_slices} slices individually using {np_workers} workers")
+
+    # Start timing parallel setup
+    parallel_setup_start_time = time.time()
+
+    # Set up global variables for worker processes
+    _setup_parallel_globals(
+        cvm_registry, vm1d_data, nz_tomography_data, global_surfaces,
+        basin_data_list, global_mesh, in_basin_mesh, partial_global_mesh_list, vm_params
+    )
+
+    # Configure HDF5 for multiprocessing
+    os.environ.setdefault("HDF5_USE_FILE_LOCKING", "FALSE")
+
+    # Create queue for worker-to-writer communication
+    mp_context = mp.get_context("spawn")
+    queue = mp_context.Queue(maxsize=np_workers * 2)
+
+    # Start HDF5 writer process
+    writer_process = start_hdf5_writer_process(
+        queue, str(out_dir), vm_params, logger
+    )
+
+    try:
+        # Submit slice blocks to worker processes
+        with ProcessPoolExecutor(
+                max_workers=np_workers,
+                mp_context=mp.get_context("fork"),
+                initializer=_init_worker_process,
+                initargs=(queue, blas_threads),
+        ) as executor:
+
+            # Submit all blocks for processing
+            futures = {
+                executor.submit(_compute_slice_block, block, use_blocks): block
+                for block in slice_blocks
+            }
+
+            # Process completed blocks with progress tracking
+            completed_slices = 0
+            first_block_completed = False
+            with tqdm(total=total_slices, desc="Processing slices", unit="slice") as pbar:
+                for future in as_completed(futures):
+                    try:
+                        future.result()  # Raise any exceptions from workers
+                        block = futures[future]
+                        completed_slices += len(block)
+                        pbar.update(len(block))
+
+                        # Log parallel setup time after first block completes
+                        if not first_block_completed:
+                            parallel_setup_elapsed_time = time.time() - parallel_setup_start_time
+                            logger.info(
+                                f"Getting ready for parallel computation in {parallel_setup_elapsed_time:.2f} seconds"
+                            )
+                            first_block_completed = True
+
+                    except (RuntimeError, ValueError) as e:
+                        logger.error(f"Worker process failed: {e}")
+                        # Cancel remaining futures
+                        for f in futures:
+                            f.cancel()
+                        raise RuntimeError(f"Parallel processing failed: {e}")
+                    except (OSError, IOError) as e:
+                        logger.error(f"File system error in worker: {e}")
+                        # Cancel remaining futures
+                        for f in futures:
+                            f.cancel()
+                        raise OSError(f"Parallel processing failed: {e}")
+
+    finally:
+        # Signal writer process to finish and wait
+        queue.put(None)  # Sentinel value
+        writer_process.join(timeout=30)
+        if writer_process.is_alive():
+            logger.warning("Writer process did not terminate gracefully")
+            writer_process.terminate()
+            writer_process.join()
+
+    logger.info("Parallel processing completed successfully")
+
+
+# ============================================================================
+# Main Processing Function
+# ============================================================================
+
+def _generate_velocity_model_impl(
+        nzcvm_cfg_path: Path,
+        out_dir: Optional[Path] = None,
+        nzcvm_registry: Optional[Path] = None,
+        model_version: Optional[str] = None,
+        output_format_str: str = WriteFormat.EMOD3D.name,
+        nzcvm_data_root: Optional[Path] = None,
+        smoothing: bool = False,
+        np_workers: Optional[int] = None,
+        blas_threads: Optional[int] = None,
+        use_blocks: bool = True,
+        log_level: str = "INFO",
+) -> None:
+    """
+    Implementation of velocity model generation.
+
+    This function orchestrates the complete velocity model generation process,
+    including setup, data loading, and choosing between serial or parallel processing.
+
+    Parameters
+    ----------
+    nzcvm_cfg_path : Path
+        Path to the NZCVM configuration file
+    out_dir : Path, optional
+        Output directory (overrides config file setting)
+    nzcvm_registry : Path, optional
+        Path to NZCVM registry file
+    model_version : str, optional
+        Model version to use (overrides config file setting)
+    output_format_str : str
+        Output format name (EMOD3D, HDF5, CSV)
+    nzcvm_data_root : Path, optional
+        Data root directory (overrides config file setting)
+    smoothing : bool
+        Whether to apply smoothing (not yet implemented)
+    np_workers : int, optional
+        Number of worker processes (None for serial processing)
+    blas_threads : int, optional
+        Number of BLAS threads per worker process
+    use_blocks : bool
+        Whether to group slices into blocks for parallel processing
+    log_level : str
+        Logging level
+    """
+    # Configure logging
+    logger.setLevel(getattr(logging, log_level.upper()))
+    start_time = time.time()
+
+    # Parse output format
+    try:
+        output_format = WriteFormat[output_format_str]
+    except KeyError:
+        valid_formats = [fmt.name for fmt in WriteFormat]
+        raise ValueError(f"Invalid output format '{output_format_str}'. Valid options: {valid_formats}")
+
+    logger.info(f"Starting velocity model generation with {output_format.value} output format")
+
+    # Determine processing mode and configure worker/thread allocation
+    if np_workers is None or np_workers <= 1:
+        logger.info("Using serial processing")
+        use_parallel = False
+        actual_workers = 1
+        actual_blas_threads = blas_threads or (os.cpu_count() or 2)
+    else:
+        # Process + BLAS budgeting
+        cores = os.cpu_count() or 2
+        actual_workers = min(np_workers, cores)
+        actual_blas_threads = blas_threads or max(1, cores // actual_workers)
+
+        logger.info(f"Using parallel processing with {actual_workers} workers")
+        logger.info(f"BLAS threads per worker: {actual_blas_threads}")
+        use_parallel = True
+
+    try:
+        # Load configuration and setup data paths
+        logger.info("Loading configuration parameters")
+        vm_params = _load_vm_params_from_cfg(nzcvm_cfg_path, out_dir, nzcvm_data_root, model_version)
+
+        # Set up data root and registry
+        data_root = nzcvm_data_root or get_data_root()
+        if nzcvm_registry is None:
+            from velocity_modelling.constants import get_registry_path
+            registry_path = get_registry_path()
+        else:
+            registry_path = nzcvm_registry
+
+        logger.info(f"Using model version: {vm_params['model_version']}")
+        logger.info(f"Using data root: {data_root}")
+        logger.info(f"Using registry: {registry_path}")
+
+        # Initialize CVM registry
+        cvm_registry = CVMRegistry(
+            version=vm_params['model_version'],
+            data_root=data_root,
+            registry_path=registry_path,
+            logger=logger
+        )
+
+        # Setup mesh and model data
+        logger.info("Generating global mesh")
+        global_mesh = gen_full_model_grid_great_circle(vm_params, logger)
+
+        logger.info("Loading model data")
+        vm1d_data, nz_tomography_data, global_surfaces, basin_data_list = cvm_registry.load_all_global_data()
+
+        # Preprocess basin membership for efficiency
+        logger.info("Preprocessing basin membership")
+        in_basin_mesh, partial_global_mesh_list = InBasinGlobalMesh.preprocess_basin_membership(
+            global_mesh, basin_data_list, logger, nz_tomography_data.smooth_boundary, actual_workers
+        )
+
+        # Set final output directory
+        final_out_dir = out_dir or vm_params['output_dir']
+        final_out_dir.mkdir(parents=True, exist_ok=True)
+        logger.info(f"Output directory: {final_out_dir}")
+
+        # Determine output writer function based on format
+        if output_format == WriteFormat.HDF5:
+            from velocity_modelling.write.hdf5 import write_global_qualities
+            logger.info("Using HDF5 output format")
+        elif output_format == WriteFormat.EMOD3D:
+            from velocity_modelling.write.emod3d import write_global_qualities
+            logger.info("Using EMOD3D output format")
+        elif output_format == WriteFormat.CSV:
+            from velocity_modelling.write.csv import write_global_qualities
+            logger.info("Using CSV output format")
+        else:
+            raise ValueError(f"Unsupported output format: {output_format}")
+
+        # Choose processing mode
+        if not use_parallel:
+            # Serial processing
+            _run_serial_processing(
+                global_mesh, in_basin_mesh, partial_global_mesh_list,
+                cvm_registry, vm1d_data, nz_tomography_data,
+                global_surfaces, basin_data_list, vm_params,
+                final_out_dir, write_global_qualities, smoothing, logger
+            )
+        else:
+            # Parallel processing - enforce HDF5 output format
+            if output_format != WriteFormat.HDF5:
+                logger.warning(
+                    f"Parallel processing requires HDF5 output format, changing from {output_format.name} to HDF5")
+                output_format = WriteFormat.HDF5
+                # Re-import the correct writer function
+                from velocity_modelling.write.hdf5 import write_global_qualities
+                logger.info("Using HDF5 output format (enforced for parallel processing)")
+
+            _run_parallel_processing(
+                global_mesh, in_basin_mesh, partial_global_mesh_list,
+                cvm_registry, vm1d_data, nz_tomography_data,
+                global_surfaces, basin_data_list, vm_params,
+                final_out_dir, actual_workers, actual_blas_threads, use_blocks, logger
+            )
+
+    except KeyboardInterrupt:
+        logger.warning("Processing interrupted by user")
+        raise
+    except (ValueError, KeyError) as e:
+        logger.error(f"Configuration or data error: {e}")
+        raise
+    except FileNotFoundError as e:
+        logger.error(f"Required file not found: {e}")
+        raise
+    except (OSError, IOError) as e:
+        logger.error(f"File system error: {e}")
+        raise
+    except RuntimeError as e:
+        logger.error(f"Processing error: {e}")
+        raise
+
+    # Report completion
+    elapsed_time = time.time() - start_time
+    logger.info(f"Velocity model generation completed successfully in {elapsed_time:.1f} seconds")
+
+
+# ============================================================================
+# CLI Entry Point
+# ============================================================================
+
+@cli.from_docstring(app)
+def generate_3d_model(
+        nzcvm_cfg_path: Annotated[Path, typer.Argument(exists=True, dir_okay=False)],
+        out_dir: Annotated[Path | None, typer.Option(file_okay=False)] = None,
+        nzcvm_registry: Annotated[
+            Path | None,
+            typer.Option(
+                exists=False,
+                dir_okay=False,
+                help="Path to nzcvm_registry.yaml (default: nzcvm_data/nzcvm_registry.yaml)",
+            ),
+        ] = None,
+        model_version: Annotated[str | None, typer.Option()] = None,
+        output_format: Annotated[str, typer.Option()] = WriteFormat.EMOD3D.name,
+        nzcvm_data_root: Annotated[
+            Path | None,
+            typer.Option(
+                file_okay=False,
+                exists=False,  # will validate later
+                help="Override the default nzcvm_data directory",
+            ),
+        ] = None,
+        smoothing: Annotated[
+            bool, typer.Option()
+        ] = False,  # placeholder for smoothing, not implemented yet
+        np_workers: Annotated[
+            int | None, typer.Option("--np")] = None,
+        blas_threads: Annotated[
+            int | None, typer.Option()] = None,
+        use_blocks: Annotated[
+            bool, typer.Option("--use-blocks/--no-use-blocks", help="Group slices into blocks for parallel processing")
+        ] = True,
+        log_level: Annotated[str, typer.Option()] = "INFO",
+) -> None:
+    """
+    Generate 3D seismic velocity model from configuration file.
+
+    This command creates a 3D velocity model by combining global velocity models,
+    regional tomographic data, and local basin models according to the parameters
+    specified in the configuration file.
+
+    Examples:
+        # Basic usage
+        nzcvm generate-3d-model config.cfg
+
+        # Parallel processing with custom output
+        nzcvm generate-3d-model config.cfg --np 8 --out-dir ./output
+
+        # HDF5 output with specific model version and BLAS threading
+        nzcvm generate-3d-model config.cfg --output-format HDF5 --model-version 2.07 --blas-threads 2
+
+        # Disable block processing for debugging
+        nzcvm generate-3d-model config.cfg --np 4 --no-use-blocks
+    """
+    try:
+        _generate_velocity_model_impl(
+            nzcvm_cfg_path=nzcvm_cfg_path,
+            out_dir=out_dir,
+            nzcvm_registry=nzcvm_registry,
+            model_version=model_version,
+            output_format_str=output_format,
+            nzcvm_data_root=nzcvm_data_root,
+            smoothing=smoothing,
+            np_workers=np_workers,
+            blas_threads=blas_threads,
+            use_blocks=use_blocks,
+            log_level=log_level,
+        )
+    except KeyboardInterrupt:
+        logger.info("Operation cancelled by user")
+        raise typer.Exit(1)
+    except (ValueError, KeyError) as e:
+        logger.error(f"Configuration error: {e}")
+        raise typer.Exit(1)
+    except FileNotFoundError as e:
+        logger.error(f"File not found: {e}")
+        raise typer.Exit(1)
+    except (OSError, IOError) as e:
+        logger.error(f"File system error: {e}")
+        raise typer.Exit(1)
+    except RuntimeError as e:
+        logger.error(f"Processing failed: {e}")
+        raise typer.Exit(1)
 
 
 if __name__ == "__main__":

--- a/velocity_modelling/tools/compare_hdf5.py
+++ b/velocity_modelling/tools/compare_hdf5.py
@@ -1,103 +1,189 @@
 #!/usr/bin/env python
-# tools/compare_hdf5.py
+# tools/compare_hdf5_chunked.py
 from pathlib import Path
 import argparse, h5py, numpy as np
 
 DATASETS = ["/properties/vp", "/properties/vs", "/properties/rho", "/properties/inbasin"]
 
-def normalize(A: h5py.File, dsname: str):
-    ds = A[dsname]
-    shape = ds.shape
-    cfg = A.get("config")
-    if cfg is None:
-        raise ValueError(f"{A.filename}: missing /config for axis mapping")
-    nx = int(cfg.attrs["nx"]); ny = int(cfg.attrs["ny"]); nz = int(cfg.attrs["nz"])
 
-    arr = np.asarray(ds[...])
+def get_axis_mapping(cfg, shape):
+    """Determine how to transpose data to (ny, nx, nz) format"""
+    nx = int(cfg.attrs["nx"]);
+    ny = int(cfg.attrs["ny"]);
+    nz = int(cfg.attrs["nz"])
 
-    # If already (ny, nx, nz), done.
+    # If already (ny, nx, nz), no transpose needed
     if shape == (ny, nx, nz):
-        return arr
+        return None
 
-    # Common serial layout (nz, nx, ny)
+    # Common serial layout (nz, nx, ny) -> (ny, nx, nz)
     if shape == (nz, nx, ny):
-        # permute to (ny, nx, nz)
-        return np.transpose(arr, (2,1,0))
+        return (2, 1, 0)
 
-    # Your earlier parallel layout (ny, nx, nz)
-    if shape == (ny, nx, nz):
-        return arr
-
-    # Fallback: try to infer by matching unique dim 'nz'
+    # Try to infer by matching unique dim 'nz'
     axes = list(shape)
     try:
         z_axis = axes.index(nz)
-        # remaining two axes should be nx, ny (equal here, so we assume order (ny, nx, nz))
-        if z_axis == 0:
-            return np.transpose(arr, (2,1,0))
-        elif z_axis == 1:
-            return np.transpose(arr, (0,2,1))
-        elif z_axis == 2:
-            return arr
+        if z_axis == 0:  # (nz, ?, ?) -> (ny, nx, nz)
+            return (2, 1, 0)
+        elif z_axis == 1:  # (?, nz, ?) -> (ny, nx, nz)
+            return (0, 2, 1)
+        elif z_axis == 2:  # (?, ?, nz) -> already correct
+            return None
     except ValueError:
         pass
-    raise ValueError(f"Unrecognized shape for {dsname}: {shape} with nx,ny,nz={nx,ny,nz}")
+
+    raise ValueError(f"Unrecognized shape: {shape} with nx,ny,nz={nx, ny, nz}")
+
 
 def stats(a, b):
+    """Calculate statistics for differences between arrays"""
     d = a - b
     mae = float(np.mean(np.abs(d)))
-    mx  = float(np.max(np.abs(d)))
-    rmse= float(np.sqrt(np.mean(d*d)))
+    mx = float(np.max(np.abs(d)))
+    rmse = float(np.sqrt(np.mean(d * d)))
     return mae, mx, rmse
 
-def compare(a_path: Path, b_path: Path, atol=1e-6, rtol=1e-6, per_slice=False):
-    out = []
-    with h5py.File(a_path, "r") as A, h5py.File(b_path, "r") as B:
-        for ds in DATASETS:
-            if ds not in A or ds not in B:
-                out.append((ds, "missing", None)); continue
-            x = normalize(A, ds)  # -> (ny, nx, nz)
-            y = normalize(B, ds)
-            if x.shape != y.shape or x.dtype != y.dtype:
-                out.append((ds, "shape/dtype mismatch", (x.shape, y.shape, str(x.dtype), str(y.dtype))))
-                continue
-            if per_slice:
-                ny = x.shape[0]; diffs=[]
-                for j in range(ny):
-                    a = x[j]; b = y[j]
-                    if not np.allclose(a, b, atol=atol, rtol=rtol, equal_nan=True):
-                        diffs.append((j,)+stats(a,b))
-                out.append((ds, "per-slice", diffs))
-            else:
-                ok = np.allclose(x, y, atol=atol, rtol=rtol, equal_nan=True)
-                out.append((ds, "ok" if ok else "differs", None if ok else stats(x,y)))
 
-        # compare selected config attrs
+def compare_chunked(ds_a, ds_b, transpose_a, transpose_b, atol=1e-6, rtol=1e-6, chunk_size=100):
+    """Compare datasets chunk by chunk along the first axis"""
+    shape_a = ds_a.shape
+    shape_b = ds_b.shape
+
+    # After transpose, shapes should match
+    expected_shape_a = shape_a if transpose_a is None else tuple(shape_a[i] for i in transpose_a)
+    expected_shape_b = shape_b if transpose_b is None else tuple(shape_b[i] for i in transpose_b)
+
+    if expected_shape_a != expected_shape_b:
+        return False, f"shape mismatch: {expected_shape_a} vs {expected_shape_b}"
+
+    if ds_a.dtype != ds_b.dtype:
+        return False, f"dtype mismatch: {ds_a.dtype} vs {ds_b.dtype}"
+
+    # Process in chunks along first dimension
+    first_dim = expected_shape_a[0]
+    all_stats = []
+    max_diff = 0
+
+    for start in range(0, first_dim, chunk_size):
+        end = min(start + chunk_size, first_dim)
+
+        # Load chunks
+        chunk_a = ds_a[start:end]
+        chunk_b = ds_b[start:end]
+
+        # Apply transpose if needed
+        if transpose_a is not None:
+            # Adjust transpose indices for the chunk (first dim is already selected)
+            if transpose_a == (2, 1, 0):  # (nz, nx, ny) -> (ny, nx, nz), but we selected first dim
+                # chunk shape is (chunk_size, nx, ny), we want (chunk_size, nx, ny) - no change needed
+                pass
+            elif transpose_a == (0, 2, 1):  # (ny, nz, nx) -> (ny, nx, nz)
+                chunk_a = np.transpose(chunk_a, (0, 2, 1))
+
+        if transpose_b is not None:
+            if transpose_b == (2, 1, 0):
+                pass
+            elif transpose_b == (0, 2, 1):
+                chunk_b = np.transpose(chunk_b, (0, 2, 1))
+
+        # Compare chunks
+        if not np.allclose(chunk_a, chunk_b, atol=atol, rtol=rtol, equal_nan=True):
+            chunk_stats = stats(chunk_a, chunk_b)
+            all_stats.append((start, end, chunk_stats))
+            max_diff = max(max_diff, chunk_stats[1])  # max absolute diff
+
+        print(f"  Processed slices {start:4d}-{end - 1:4d} / {first_dim - 1}")
+
+    if all_stats:
+        return False, f"differences found in {len(all_stats)} chunks, max_diff={max_diff:.2e}"
+    else:
+        return True, "chunks match"
+
+
+def compare(a_path: Path, b_path: Path, atol=1e-6, rtol=1e-6, chunk_size=100):
+    """Compare HDF5 files using chunked processing"""
+    out = []
+
+    with h5py.File(a_path, "r") as A, h5py.File(b_path, "r") as B:
+        for ds_name in DATASETS:
+            print(f"\nComparing {ds_name}...")
+
+            if ds_name not in A or ds_name not in B:
+                out.append((ds_name, "missing", None))
+                continue
+
+            ds_a = A[ds_name]
+            ds_b = B[ds_name]
+
+            # Get config for axis mapping
+            cfg_a = A.get("config")
+            cfg_b = B.get("config")
+
+            if cfg_a is None or cfg_b is None:
+                out.append((ds_name, "missing config", None))
+                continue
+
+            try:
+                transpose_a = get_axis_mapping(cfg_a, ds_a.shape)
+                transpose_b = get_axis_mapping(cfg_b, ds_b.shape)
+
+                print(f"  Shape A: {ds_a.shape}, transpose: {transpose_a}")
+                print(f"  Shape B: {ds_b.shape}, transpose: {transpose_b}")
+
+                is_match, info = compare_chunked(ds_a, ds_b, transpose_a, transpose_b,
+                                                 atol, rtol, chunk_size)
+
+                status = "ok" if is_match else "differs"
+                out.append((ds_name, status, info))
+
+            except Exception as e:
+                out.append((ds_name, "error", str(e)))
+
+        # Compare config attributes
+        print(f"\nComparing config attributes...")
         CA, CB = A.get("config"), B.get("config")
         if CA and CB:
             keysA, keysB = set(CA.attrs), set(CB.attrs)
-            # tolerate extra keys, only assert common ones
             common = sorted(keysA & keysB)
-            skews=[]
+            skews = []
+
             for k in common:
                 va, vb = CA.attrs[k], CB.attrs[k]
-                if isinstance(va,(int,float)) and isinstance(vb,(int,float)):
+                if isinstance(va, (int, float)) and isinstance(vb, (int, float)):
                     if not np.isclose(va, vb, atol=atol, rtol=rtol):
                         skews.append((k, va, vb))
                 else:
                     if str(va) != str(vb):
                         skews.append((k, va, vb))
-            out.append(("config", "ok" if not skews else "attr-values mismatch", skews))
+
+            status = "ok" if not skews else "attr-values mismatch"
+            out.append(("config", status, skews))
+
     return out
 
+
 if __name__ == "__main__":
-    ap = argparse.ArgumentParser()
-    ap.add_argument("a", type=Path)
-    ap.add_argument("b", type=Path)
-    ap.add_argument("--atol", type=float, default=1e-6)
-    ap.add_argument("--rtol", type=float, default=1e-6)
-    ap.add_argument("--per-slice", action="store_true")
+    ap = argparse.ArgumentParser(description="Compare large HDF5 files using chunked processing")
+    ap.add_argument("a", type=Path, help="First HDF5 file")
+    ap.add_argument("b", type=Path, help="Second HDF5 file")
+    ap.add_argument("--atol", type=float, default=1e-6, help="Absolute tolerance")
+    ap.add_argument("--rtol", type=float, default=1e-6, help="Relative tolerance")
+    ap.add_argument("--chunk-size", type=int, default=100,
+                    help="Number of slices to process at once (reduce if memory issues)")
     args = ap.parse_args()
-    res = compare(args.a, args.b, args.atol, args.rtol, args.per_slice)
+
+    print(f"Comparing {args.a} vs {args.b}")
+    print(f"Tolerances: atol={args.atol}, rtol={args.rtol}")
+    print(f"Chunk size: {args.chunk_size} slices")
+
+    res = compare(args.a, args.b, args.atol, args.rtol, args.chunk_size)
+
+    print(f"\n{'=' * 60}")
+    print("COMPARISON RESULTS:")
+    print(f"{'=' * 60}")
+
     for ds, status, info in res:
-        print(f"{ds:>22s} : {status}", "" if info is None else info)
+        print(f"{ds:>22s} : {status}")
+        if info and info != "chunks match":
+            print(f"{'':>25s}   {info}")

--- a/velocity_modelling/tools/compare_hdf5.py
+++ b/velocity_modelling/tools/compare_hdf5.py
@@ -25,6 +25,7 @@ from typing import Annotated, Any
 import h5py
 import numpy as np
 import typer
+
 from qcore import cli
 
 app = typer.Typer(pretty_exceptions_enable=False)
@@ -61,12 +62,12 @@ def stats(a: np.ndarray, b: np.ndarray) -> tuple[float, float, float]:
 
 
 def sample_comparison(
-        ds_a: h5py.Dataset,
-        ds_b: h5py.Dataset,
-        n_samples: int = 10000,
-        atol: float = 1e-6,
-        rtol: float = 1e-6,
-        seed: int = 42,
+    ds_a: h5py.Dataset,
+    ds_b: h5py.Dataset,
+    n_samples: int = 10000,
+    atol: float = 1e-6,
+    rtol: float = 1e-6,
+    seed: int = 42,
 ) -> tuple[bool, str]:
     """
     Compare datasets using statistical sampling of random points.
@@ -144,11 +145,11 @@ def sample_comparison(
 
 
 def systematic_slice_check(
-        ds_a: h5py.Dataset,
-        ds_b: h5py.Dataset,
-        n_slices: int = 50,
-        atol: float = 1e-6,
-        rtol: float = 1e-6,
+    ds_a: h5py.Dataset,
+    ds_b: h5py.Dataset,
+    n_slices: int = 50,
+    atol: float = 1e-6,
+    rtol: float = 1e-6,
 ) -> tuple[bool, str]:
     """
     Check a systematic sample of complete slices along the first dimension.
@@ -206,7 +207,7 @@ def systematic_slice_check(
             slice_stats = stats(slice_a, slice_b)
             differences.append((slice_idx, slice_stats))
 
-        status = 'OK' if len(differences) == i else 'DIFF'
+        status = "OK" if len(differences) == i else "DIFF"
         print(f"    Slice {slice_idx:4d}: {status}")
 
     if differences:
@@ -220,9 +221,9 @@ def systematic_slice_check(
 
 
 def hash_comparison(
-        ds_a: h5py.Dataset,
-        ds_b: h5py.Dataset,
-        chunk_slices: int = 100,
+    ds_a: h5py.Dataset,
+    ds_b: h5py.Dataset,
+    chunk_slices: int = 100,
 ) -> tuple[bool, str]:
     """
     Compare using MD5 hash of chunks along the first dimension.
@@ -279,7 +280,7 @@ def hash_comparison(
         if hash_a != hash_b:
             hash_diffs.append((start, end))
 
-        status = 'SAME' if hash_a == hash_b else 'DIFF'
+        status = "SAME" if hash_a == hash_b else "DIFF"
         print(f"    Chunk {start:4d}-{end - 1:4d}: {status}")
 
     if hash_diffs:
@@ -289,14 +290,14 @@ def hash_comparison(
 
 
 def compare_datasets(
-        a_path: Path,
-        b_path: Path,
-        method: str = "sample",
-        atol: float = 1e-6,
-        rtol: float = 1e-6,
-        n_samples: int = 10000,
-        n_slices: int = 50,
-        chunk_slices: int = 100,
+    a_path: Path,
+    b_path: Path,
+    method: str = "sample",
+    atol: float = 1e-6,
+    rtol: float = 1e-6,
+    n_samples: int = 10000,
+    n_slices: int = 50,
+    chunk_slices: int = 100,
 ) -> list[tuple[str, str, Any]]:
     """
     Compare HDF5 datasets using specified method.
@@ -412,26 +413,32 @@ def compare_datasets(
                         else:
                             config_diffs.append(f"{key}: {val_a} vs {val_b}")
 
-
-
             status = "identical" if not config_diffs else "differs"
-            results.append(("config", status, config_diffs if config_diffs else "all attributes match"))
+            results.append(
+                (
+                    "config",
+                    status,
+                    config_diffs if config_diffs else "all attributes match",
+                )
+            )
         else:
-            results.append(("config", "missing", "config group not found in one or both files"))
+            results.append(
+                ("config", "missing", "config group not found in one or both files")
+            )
 
     return results
 
 
 @cli.from_docstring(app)
 def compare_hdf5_regression(
-        a: Annotated[Path, typer.Argument(exists=True, dir_okay=False)],
-        b: Annotated[Path, typer.Argument(exists=True, dir_okay=False)],
-        method: str = "sample",
-        atol: float  = 1e-6,
-        rtol: float = 1e-6,
-        n_samples: int = 10000,
-        n_slices: int = 50,
-        chunk_slices: int = 100,
+    a: Annotated[Path, typer.Argument(exists=True, dir_okay=False)],
+    b: Annotated[Path, typer.Argument(exists=True, dir_okay=False)],
+    method: str = "sample",
+    atol: float = 1e-6,
+    rtol: float = 1e-6,
+    n_samples: int = 10000,
+    n_slices: int = 50,
+    chunk_slices: int = 100,
 ) -> None:
     """
     Efficient regression test comparison of large HDF5 velocity model files.

--- a/velocity_modelling/tools/compare_hdf5.py
+++ b/velocity_modelling/tools/compare_hdf5.py
@@ -1,36 +1,26 @@
 #!/usr/bin/env python
 """
-compare_hdf5_sampling.py: Fast comparison of HDF5 velocity model files.
+Efficient HDF5 regression comparison for large files.
 
-This script provides several methods for comparing large HDF5 files containing seismic velocity models:
-  - Statistical sampling (recommended): samples random points for efficient comparison.
-  - Systematic slice checking: compares complete slices for thoroughness.
-  - Hash comparison: compares MD5 hashes of chunks for very fast integrity checks.
+This script provides efficient methods for comparing large HDF5 files that should be identical
+(regression testing). It removes unnecessary transpose complexity while keeping the fast
+comparison methods for handling very large files.
 
 Usage examples:
     # Statistical sampling (recommended) - samples 10,000 random points
-    python compare_hdf5_sampling.py vm3_24Sep/velocity_model.h5 vm3_25Sep/velocity_model.h5 --method sample --n-samples 10000
+    python compare_hdf5_regression.py file1.h5 file2.h5 --method sample --n-samples 10000
 
     # Systematic slice checking - checks 50 complete slices
-    python compare_hdf5_sampling.py vm3_24Sep/velocity_model.h5 vm3_25Sep/velocity_model.h5 --method slices --n-slices 50
+    python compare_hdf5_regression.py file1.h5 file2.h5 --method slices --n-slices 50
 
     # Hash comparison - very fast, compares MD5 hashes of chunks
-    python compare_hdf5_sampling.py vm3_24Sep/velocity_model.h5 vm3_25Sep/velocity_model.h5 --method hash
-
-For more detailed comparison, consider using h5diff:
-    # Basic comparison
-    h5diff vm3_24Sep/velocity_model.h5 vm3_25Sep/velocity_model.h5
-
-    # With tolerance
-    h5diff -d 1e-6 vm3_24Sep/velocity_model.h5 vm3_25Sep/velocity_model.h5
-
-    # Compare specific datasets
-    h5diff -d 1e-6 vm3_24Sep/velocity_model.h5 vm3_25Sep/velocity_model.h5 /properties/vp /properties/vp
+    python compare_hdf5_regression.py file1.h5 file2.h5 --method hash
 """
 
+import hashlib
 import time
 from pathlib import Path
-from typing import Annotated, Any, Optional
+from typing import Annotated, Any
 
 import h5py
 import numpy as np
@@ -47,50 +37,6 @@ DATASETS = [
 ]
 
 
-def get_axis_mapping(
-        cfg: h5py.Group, shape: tuple[int, ...]
-) -> Optional[tuple[int, ...]]:
-    """
-    Determine how to transpose data to (ny, nx, nz) format.
-
-    Parameters
-    ----------
-    cfg : h5py.Group
-        HDF5 config group containing nx, ny, nz attributes.
-    shape : tuple[int, ...]
-        Current shape of the dataset.
-
-    Returns
-    -------
-    tuple[int, ...] or None
-        Transpose indices to convert to (ny, nx, nz), or None if no transpose needed.
-    """
-    nx = int(cfg.attrs["nx"])
-    ny = int(cfg.attrs["ny"])
-    nz = int(cfg.attrs["nz"])
-
-    if shape == (ny, nx, nz):
-        return None
-    elif shape == (nz, nx, ny):
-        return (2, 1, 0)
-    elif shape == (ny, nz, nx):
-        return (0, 2, 1)
-    else:
-        # Try to infer
-        axes = list(shape)
-        try:
-            z_axis = axes.index(nz)
-            if z_axis == 0:
-                return (2, 1, 0)
-            elif z_axis == 1:
-                return (0, 2, 1)
-            elif z_axis == 2:
-                return None
-        except ValueError:
-            pass
-        raise ValueError(f"Unrecognized shape: {shape} with nx,ny,nz={nx, ny, nz}")
-
-
 def stats(a: np.ndarray, b: np.ndarray) -> tuple[float, float, float]:
     """
     Calculate statistics for differences between arrays.
@@ -98,14 +44,14 @@ def stats(a: np.ndarray, b: np.ndarray) -> tuple[float, float, float]:
     Parameters
     ----------
     a : np.ndarray
-        First array.
+        First array for comparison.
     b : np.ndarray
-        Second array.
+        Second array for comparison.
 
     Returns
     -------
     tuple[float, float, float]
-        Tuple of (MAE, max absolute difference, RMSE).
+        Tuple containing (mean_absolute_error, max_absolute_error, root_mean_square_error).
     """
     d = a - b
     mae = float(np.mean(np.abs(d)))
@@ -117,16 +63,17 @@ def stats(a: np.ndarray, b: np.ndarray) -> tuple[float, float, float]:
 def sample_comparison(
         ds_a: h5py.Dataset,
         ds_b: h5py.Dataset,
-        transpose_a: Optional[tuple[int, ...]],
-        transpose_b: Optional[tuple[int, ...]],
-        target_shape: tuple[int, int, int],
-        n_samples: int = 1000,
+        n_samples: int = 10000,
         atol: float = 1e-6,
         rtol: float = 1e-6,
         seed: int = 42,
 ) -> tuple[bool, str]:
     """
-    Compare datasets using statistical sampling.
+    Compare datasets using statistical sampling of random points.
+
+    This method provides a statistically representative comparison by sampling
+    random points throughout the dataset. It's efficient for large datasets
+    while providing good confidence in the comparison results.
 
     Parameters
     ----------
@@ -134,60 +81,51 @@ def sample_comparison(
         First dataset to compare.
     ds_b : h5py.Dataset
         Second dataset to compare.
-    transpose_a : tuple[int, ...] or None
-        Transpose indices for first dataset.
-    transpose_b : tuple[int, ...] or None
-        Transpose indices for second dataset.
-    target_shape : tuple[int, int, int]
-        Target shape (ny, nx, nz).
-    n_samples : int
-        Number of random samples to compare.
-    atol : float
-        Absolute tolerance for comparison.
-    rtol : float
-        Relative tolerance for comparison.
-    seed : int
-        Random seed for reproducibility.
+    n_samples : int, optional
+        Number of random samples to compare, by default 10000.
+    atol : float, optional
+        Absolute tolerance for comparison, by default 1e-6.
+    rtol : float, optional
+        Relative tolerance for comparison, by default 1e-6.
+    seed : int, optional
+        Random seed for reproducibility, by default 42.
 
     Returns
     -------
     tuple[bool, str]
-        Tuple of (matches, info_string).
+        Tuple of (datasets_match, statistics_string) where datasets_match
+        indicates if the sampled points are within tolerance and statistics_string
+        contains comparison metrics.
+
+    Raises
+    ------
+    ValueError
+        If datasets have incompatible shapes or dtypes.
     """
+    if ds_a.shape != ds_b.shape:
+        return False, f"shape mismatch: {ds_a.shape} vs {ds_b.shape}"
+
     if ds_a.dtype != ds_b.dtype:
         return False, f"dtype mismatch: {ds_a.dtype} vs {ds_b.dtype}"
 
-    # Use original shapes for index generation
-    orig_shape_a = ds_a.shape
-    orig_shape_b = ds_b.shape
-
-    ny, nx, nz = target_shape
     np.random.seed(seed)
+    shape = ds_a.shape
 
-    print(f"  Sampling {n_samples} random points from {ny}×{nx}×{nz} array...")
-    print(f"  Original shapes: A={orig_shape_a}, B={orig_shape_b}")
+    print(f"  Sampling {n_samples} random points from {shape} array...")
 
-    # Generate random indices for ORIGINAL shapes
-    indices_a = []
-    indices_b = []
-
+    # Generate random indices for the actual storage shape
+    indices = []
     for _ in range(n_samples):
-        # Generate random indices for original array dimensions
-        idx_a = tuple(np.random.randint(0, dim) for dim in orig_shape_a)
-        idx_b = tuple(np.random.randint(0, dim) for dim in orig_shape_b)
-        indices_a.append(idx_a)
-        indices_b.append(idx_b)
+        idx = tuple(np.random.randint(0, dim) for dim in shape)
+        indices.append(idx)
 
-    # Sample from both datasets
+    # Sample from both datasets using identical indices
     sample_a = []
     sample_b = []
 
-    for i, (idx_a, idx_b) in enumerate(zip(indices_a, indices_b)):
-        val_a = ds_a[idx_a]
-        val_b = ds_b[idx_b]
-
-        sample_a.append(val_a)
-        sample_b.append(val_b)
+    for i, idx in enumerate(indices):
+        sample_a.append(ds_a[idx])
+        sample_b.append(ds_b[idx])
 
         if (i + 1) % 1000 == 0:
             print(f"    Sampled {i + 1}/{n_samples} points...")
@@ -208,15 +146,16 @@ def sample_comparison(
 def systematic_slice_check(
         ds_a: h5py.Dataset,
         ds_b: h5py.Dataset,
-        transpose_a: tuple[int, ...] | None,
-        transpose_b: tuple[int, ...] | None,
-        target_shape: tuple[int, int, int],
-        n_slices: int = 20,
+        n_slices: int = 50,
         atol: float = 1e-6,
         rtol: float = 1e-6,
 ) -> tuple[bool, str]:
     """
-    Check a systematic sample of complete slices.
+    Check a systematic sample of complete slices along the first dimension.
+
+    This method provides thorough checking by comparing complete slices
+    systematically distributed throughout the dataset. It's more comprehensive
+    than sampling but still efficient for large datasets.
 
     Parameters
     ----------
@@ -224,57 +163,51 @@ def systematic_slice_check(
         First dataset to compare.
     ds_b : h5py.Dataset
         Second dataset to compare.
-    transpose_a : tuple[int, ...] or None
-        Transpose indices for first dataset.
-    transpose_b : tuple[int, ...] or None
-        Transpose indices for second dataset.
-    target_shape : tuple[int, int, int]
-        Target shape (ny, nx, nz).
-    n_slices : int
-        Number of slices to check.
-    atol : float
-        Absolute tolerance for comparison.
-    rtol : float
-        Relative tolerance for comparison.
+    n_slices : int, optional
+        Number of slices to check, by default 50.
+    atol : float, optional
+        Absolute tolerance for comparison, by default 1e-6.
+    rtol : float, optional
+        Relative tolerance for comparison, by default 1e-6.
 
     Returns
     -------
     tuple[bool, str]
-        Tuple of (matches, info_string).
+        Tuple of (all_slices_match, summary_string) where all_slices_match
+        indicates if all checked slices are within tolerance and summary_string
+        contains details about any differences found.
+
+    Raises
+    ------
+    ValueError
+        If datasets have incompatible shapes or dtypes.
     """
-    ny, nx, nz = target_shape
-    slice_indices = np.linspace(0, ny - 1, n_slices, dtype=int)
+    if ds_a.shape != ds_b.shape:
+        return False, f"shape mismatch: {ds_a.shape} vs {ds_b.shape}"
+
+    if ds_a.dtype != ds_b.dtype:
+        return False, f"dtype mismatch: {ds_a.dtype} vs {ds_b.dtype}"
+
+    shape = ds_a.shape
+    first_dim = shape[0]
+    slice_indices = np.linspace(0, first_dim - 1, n_slices, dtype=int)
 
     print(f"  Checking {n_slices} systematic slices: {list(slice_indices)}")
 
     differences = []
 
     for i, slice_idx in enumerate(slice_indices):
-        # Load slice
-        if transpose_a == (2, 1, 0):  # (nz, nx, ny)
-            slice_a = ds_a[:, :, slice_idx]  # (nz, nx)
-            slice_a = slice_a.T  # -> (nx, nz)
-        elif transpose_a == (0, 2, 1):  # (ny, nz, nx)
-            slice_a = ds_a[slice_idx, :, :]  # (nz, nx)
-            slice_a = slice_a.T  # -> (nx, nz)
-        else:  # (ny, nx, nz)
-            slice_a = ds_a[slice_idx, :, :]  # (nx, nz)
+        # Load corresponding slices from both datasets
+        slice_a = ds_a[slice_idx]
+        slice_b = ds_b[slice_idx]
 
-        if transpose_b == (2, 1, 0):
-            slice_b = ds_b[:, :, slice_idx]
-            slice_b = slice_b.T
-        elif transpose_b == (0, 2, 1):
-            slice_b = ds_b[slice_idx, :, :]
-            slice_b = slice_b.T
-        else:
-            slice_b = ds_b[slice_idx, :, :]
-
-        # Compare slice
+        # Compare slices
         if not np.allclose(slice_a, slice_b, atol=atol, rtol=rtol, equal_nan=True):
             slice_stats = stats(slice_a, slice_b)
             differences.append((slice_idx, slice_stats))
 
-        print(f"    Slice {slice_idx:4d}: {'OK' if len(differences) == i else 'DIFF'}")
+        status = 'OK' if len(differences) == i else 'DIFF'
+        print(f"    Slice {slice_idx:4d}: {status}")
 
     if differences:
         max_diff = max(diff[1][1] for diff in differences)  # max of max diffs
@@ -289,13 +222,14 @@ def systematic_slice_check(
 def hash_comparison(
         ds_a: h5py.Dataset,
         ds_b: h5py.Dataset,
-        transpose_a: tuple[int, ...] | None,
-        transpose_b: tuple[int, ...] | None,
-        target_shape: tuple[int, int, int],
         chunk_slices: int = 100,
 ) -> tuple[bool, str]:
     """
-    Compare using hash/checksum of chunks.
+    Compare using MD5 hash of chunks along the first dimension.
+
+    This method provides the fastest comparison by computing MD5 hashes
+    of data chunks. It can detect any differences but doesn't provide
+    quantitative information about the magnitude of differences.
 
     Parameters
     ----------
@@ -303,47 +237,40 @@ def hash_comparison(
         First dataset to compare.
     ds_b : h5py.Dataset
         Second dataset to compare.
-    transpose_a : tuple[int, ...] or None
-        Transpose indices for first dataset.
-    transpose_b : tuple[int, ...] or None
-        Transpose indices for second dataset.
-    target_shape : tuple[int, int, int]
-        Target shape (ny, nx, nz).
-    chunk_slices : int
-        Number of slices per chunk for hashing.
+    chunk_slices : int, optional
+        Number of slices per chunk for hashing, by default 100.
 
     Returns
     -------
     tuple[bool, str]
-        Tuple of (matches, info_string).
-    """
-    import hashlib
+        Tuple of (hashes_match, summary_string) where hashes_match indicates
+        if all chunk hashes are identical and summary_string contains details
+        about any differing chunks.
 
-    ny, nx, nz = target_shape
+    Raises
+    ------
+    ValueError
+        If datasets have incompatible shapes or dtypes.
+    """
+    if ds_a.shape != ds_b.shape:
+        return False, f"shape mismatch: {ds_a.shape} vs {ds_b.shape}"
+
+    if ds_a.dtype != ds_b.dtype:
+        return False, f"dtype mismatch: {ds_a.dtype} vs {ds_b.dtype}"
+
+    shape = ds_a.shape
+    first_dim = shape[0]
 
     print(f"  Computing hashes for chunks of {chunk_slices} slices...")
 
     hash_diffs = []
 
-    for start in range(0, ny, chunk_slices):
-        end = min(start + chunk_slices, ny)
+    for start in range(0, first_dim, chunk_slices):
+        end = min(start + chunk_slices, first_dim)
 
-        # Load chunks
-        if transpose_a == (2, 1, 0):  # (nz, nx, ny)
-            chunk_a = ds_a[:, :, start:end]
-            chunk_a = np.transpose(chunk_a, (2, 1, 0))  # -> (chunk_size, nx, nz)
-        else:
-            chunk_a = ds_a[start:end]
-            if transpose_a:
-                chunk_a = np.transpose(chunk_a, transpose_a)
-
-        if transpose_b == (2, 1, 0):
-            chunk_b = ds_b[:, :, start:end]
-            chunk_b = np.transpose(chunk_b, (2, 1, 0))
-        else:
-            chunk_b = ds_b[start:end]
-            if transpose_b:
-                chunk_b = np.transpose(chunk_b, transpose_b)
+        # Load chunks from both datasets
+        chunk_a = ds_a[start:end]
+        chunk_b = ds_b[start:end]
 
         # Compute hashes
         hash_a = hashlib.md5(chunk_a.tobytes()).hexdigest()
@@ -352,9 +279,8 @@ def hash_comparison(
         if hash_a != hash_b:
             hash_diffs.append((start, end))
 
-        print(
-            f"    Chunk {start:4d}-{end - 1:4d}: {'SAME' if hash_a == hash_b else 'DIFF'}"
-        )
+        status = 'SAME' if hash_a == hash_b else 'DIFF'
+        print(f"    Chunk {start:4d}-{end - 1:4d}: {status}")
 
     if hash_diffs:
         return False, f"{len(hash_diffs)} chunks have different hashes: {hash_diffs}"
@@ -362,17 +288,22 @@ def hash_comparison(
         return True, "all chunk hashes match"
 
 
-def compare_fast(
+def compare_datasets(
         a_path: Path,
         b_path: Path,
+        method: str = "sample",
         atol: float = 1e-6,
         rtol: float = 1e-6,
-        method: str = "sample",
-        n_samples: int = 1000,
-        n_slices: int = 20,
+        n_samples: int = 10000,
+        n_slices: int = 50,
+        chunk_slices: int = 100,
 ) -> list[tuple[str, str, Any]]:
     """
-    Fast comparison using various methods.
+    Compare HDF5 datasets using specified method.
+
+    This function orchestrates the comparison of all standard velocity model
+    datasets in two HDF5 files using the specified comparison method. It also
+    compares configuration metadata.
 
     Parameters
     ----------
@@ -380,21 +311,33 @@ def compare_fast(
         Path to first HDF5 file.
     b_path : Path
         Path to second HDF5 file.
-    atol : float
-        Absolute tolerance for comparison.
-    rtol : float
-        Relative tolerance for comparison.
-    method : str
-        Comparison method: 'sample', 'slices', or 'hash'.
-    n_samples : int
-        Number of samples for sample method.
-    n_slices : int
-        Number of slices for slice method.
+    method : str, optional
+        Comparison method: 'sample', 'slices', or 'hash', by default "sample".
+    atol : float, optional
+        Absolute tolerance for comparison, by default 1e-6.
+    rtol : float, optional
+        Relative tolerance for comparison, by default 1e-6.
+    n_samples : int, optional
+        Number of samples for sample method, by default 10000.
+    n_slices : int, optional
+        Number of slices for slice method, by default 50.
+    chunk_slices : int, optional
+        Slices per chunk for hash method, by default 100.
 
     Returns
     -------
     list[tuple[str, str, Any]]
-        List of (dataset_name, status, info) tuples.
+        List of (dataset_name, status, info) tuples where:
+        - dataset_name: Name of the dataset or 'config'
+        - status: 'identical', 'differs', 'missing', or 'error'
+        - info: Details about the comparison result or error message
+
+    Raises
+    ------
+    ValueError
+        If an invalid comparison method is specified.
+    FileNotFoundError
+        If either HDF5 file cannot be opened.
     """
     methods = {
         "sample": sample_comparison,
@@ -405,7 +348,7 @@ def compare_fast(
     if method not in methods:
         raise ValueError(f"Method must be one of: {list(methods.keys())}")
 
-    out = []
+    results = []
 
     with h5py.File(a_path, "r") as file_a, h5py.File(b_path, "r") as file_b:
         for ds_name in DATASETS:
@@ -413,127 +356,201 @@ def compare_fast(
             start_time = time.time()
 
             if ds_name not in file_a or ds_name not in file_b:
-                out.append((ds_name, "missing", None))
+                results.append((ds_name, "missing", None))
                 continue
 
             ds_a = file_a[ds_name]
             ds_b = file_b[ds_name]
 
-            cfg_a = file_a.get("config")
-            cfg_b = file_b.get("config")
-
-            if cfg_a is None or cfg_b is None:
-                out.append((ds_name, "missing config", None))
-                continue
-
             try:
-                transpose_a = get_axis_mapping(cfg_a, ds_a.shape)
-                transpose_b = get_axis_mapping(cfg_b, ds_b.shape)
-
-                # Determine target shape after transpose
-                nx = int(cfg_a.attrs["nx"])
-                ny = int(cfg_a.attrs["ny"])
-                nz = int(cfg_a.attrs["nz"])
-                target_shape = (ny, nx, nz)
-
-                print(f"  Shape A: {ds_a.shape}, transpose: {transpose_a}")
-                print(f"  Shape B: {ds_b.shape}, transpose: {transpose_b}")
-
                 # Apply chosen method
                 if method == "sample":
                     is_match, info = sample_comparison(
-                        ds_a,
-                        ds_b,
-                        transpose_a,
-                        transpose_b,
-                        target_shape,
-                        n_samples,
-                        atol,
-                        rtol,
+                        ds_a, ds_b, n_samples, atol, rtol
                     )
                 elif method == "slices":
                     is_match, info = systematic_slice_check(
-                        ds_a,
-                        ds_b,
-                        transpose_a,
-                        transpose_b,
-                        target_shape,
-                        n_slices,
-                        atol,
-                        rtol,
+                        ds_a, ds_b, n_slices, atol, rtol
                     )
                 elif method == "hash":
-                    is_match, info = hash_comparison(
-                        ds_a, ds_b, transpose_a, transpose_b, target_shape
-                    )
+                    is_match, info = hash_comparison(ds_a, ds_b, chunk_slices)
 
                 elapsed = time.time() - start_time
-                status = "ok" if is_match else "differs"
-                out.append((ds_name, status, f"{info} ({elapsed:.1f}s)"))
+                status = "identical" if is_match else "differs"
+                results.append((ds_name, status, f"{info} ({elapsed:.1f}s)"))
 
             except (KeyError, ValueError, OSError) as e:
-                out.append((ds_name, "error", str(e)))
+                results.append((ds_name, "error", str(e)))
 
-        # Config comparison (fast)
-        config_a, config_b = file_a.get("config"), file_b.get("config")
+        # Config comparison
+        config_a = file_a.get("config")
+        config_b = file_b.get("config")
+
         if config_a and config_b:
+            config_diffs = []
             keys_a, keys_b = set(config_a.attrs), set(config_b.attrs)
-            common = sorted(keys_a & keys_b)
-            skews = []
-            for k in common:
-                va, vb = config_a.attrs[k], config_b.attrs[k]
-                if isinstance(va, (int, float)) and isinstance(vb, (int, float)):
-                    if not np.isclose(va, vb, atol=atol, rtol=rtol):
-                        skews.append((k, va, vb))
-                else:
-                    if str(va) != str(vb):
-                        skews.append((k, va, vb))
-            out.append(("config", "ok" if not skews else "differs", skews))
 
-    return out
+            # Compare keys
+            if keys_a != keys_b:
+                missing_a = keys_b - keys_a
+                missing_b = keys_a - keys_b
+                if missing_a:
+                    config_diffs.append(f"missing in A: {missing_a}")
+                if missing_b:
+                    config_diffs.append(f"missing in B: {missing_b}")
+
+            # Compare values
+            for key in keys_a & keys_b:
+                val_a, val_b = config_a.attrs[key], config_b.attrs[key]
+                if isinstance(val_a, (int, float)) and isinstance(val_b, (int, float)):
+                    if not np.isclose(val_a, val_b, atol=atol, rtol=rtol):
+                        config_diffs.append(f"{key}: {val_a} vs {val_b}")
+                else:
+                    if str(val_a) != str(val_b):
+                        if key == "config_string":
+                            config_diffs.append(f"{key}:\n\n{val_a}\n\nvs\n\n{val_b}")
+                        else:
+                            config_diffs.append(f"{key}: {val_a} vs {val_b}")
+
+
+
+            status = "identical" if not config_diffs else "differs"
+            results.append(("config", status, config_diffs if config_diffs else "all attributes match"))
+        else:
+            results.append(("config", "missing", "config group not found in one or both files"))
+
+    return results
 
 
 @cli.from_docstring(app)
-def compare_hdf5_sampling(
-        a: Annotated[Path, typer.Argument(exists=True, dir_okay=False, help="First HDF5 file")],
-        b: Annotated[Path, typer.Argument(exists=True, dir_okay=False, help="Second HDF5 file")],
-        method: Annotated[str, typer.Option(help="Comparison method")] = "sample",
-        atol: Annotated[float, typer.Option(help="Absolute tolerance")] = 1e-6,
-        rtol: Annotated[float, typer.Option(help="Relative tolerance")] = 1e-6,
-        n_samples: Annotated[int, typer.Option(help="Number of random samples (for sample method)")] = 10000,
-        n_slices: Annotated[int, typer.Option(help="Number of slices to check (for slices method)")] = 50,
+def compare_hdf5_regression(
+        a: Annotated[Path, typer.Argument(exists=True, dir_okay=False)],
+        b: Annotated[Path, typer.Argument(exists=True, dir_okay=False)],
+        method: str = "sample",
+        atol: float  = 1e-6,
+        rtol: float = 1e-6,
+        n_samples: int = 10000,
+        n_slices: int = 50,
+        chunk_slices: int = 100,
 ) -> None:
     """
-    Fast comparison of HDF5 velocity model files.
+    Efficient regression test comparison of large HDF5 velocity model files.
 
-    Provides several methods for comparing large HDF5 files containing seismic velocity models:
-      - Statistical sampling (recommended): samples random points for efficient comparison
-      - Systematic slice checking: compares complete slices for thoroughness
-      - Hash comparison: compares MD5 hashes of chunks for very fast integrity checks
+    This tool provides three efficient methods for comparing large velocity model
+    files that should be identical (for regression testing):
+
+    - **sample**: Statistical sampling of random points (recommended for most cases)
+      Samples n_samples random points throughout each dataset and compares them.
+      Fast and statistically representative.
+
+    - **slices**: Systematic checking of complete slices (thorough)
+      Checks n_slices complete slices systematically distributed through the dataset.
+      More comprehensive than sampling but still efficient.
+
+    - **hash**: MD5 hash comparison of chunks (fastest, detects any differences)
+      Computes MD5 hashes of data chunks and compares them.
+      Fastest method that can detect any differences, but doesn't quantify them.
+
+    The tool compares standard velocity model datasets (/properties/vp, /properties/vs,
+    /properties/rho, /properties/inbasin) and configuration metadata. It exits with
+    code 0 if data is identical and code 1 if differences are found.
+
+    Parameters
+    ----------
+    a : Path
+        Path to the first HDF5 file to compare.
+    b : Path
+        Path to the second HDF5 file to compare.
+    method : str, optional
+        Comparison method to use, by default "sample".
+    atol : float, optional
+        Absolute tolerance for numerical comparisons, by default 1e-6.
+    rtol : float, optional
+        Relative tolerance for numerical comparisons, by default 1e-6.
+    n_samples : int, optional
+        Number of random samples to compare when using 'sample' method, by default 10000.
+    n_slices : int, optional
+        Number of slices to check when using 'slices' method, by default 50.
+    chunk_slices : int, optional
+        Number of slices per chunk when using 'hash' method, by default 100.
+
+    Raises
+    ------
+    typer.BadParameter
+        If an invalid comparison method is specified.
+    typer.Exit
+        Exits with code 1 if files differ, code 0 if identical.
+    FileNotFoundError
+        If either input file cannot be found or opened.
+
+    Examples
+    --------
+    Compare two files using statistical sampling:
+
+    >>> compare_hdf5_regression(Path("file1.h5"), Path("file2.h5"), method="sample", n_samples=5000)
+
+    Compare using systematic slice checking:
+
+    >>> compare_hdf5_regression(Path("file1.h5"), Path("file2.h5"), method="slices", n_slices=25)
+
+    Quick hash-based comparison:
+
+    >>> compare_hdf5_regression(Path("file1.h5"), Path("file2.h5"), method="hash")
     """
     # Validate method
     valid_methods = ["sample", "slices", "hash"]
     if method not in valid_methods:
         raise typer.BadParameter(f"Method must be one of: {valid_methods}")
 
-    print(f"Fast comparing {a} vs {b}")
+    print(f"Efficient regression comparison: {a} vs {b}")
     print(f"Method: {method}")
-    print(f"Tolerances: atol={atol}, rtol={rtol}")
+    if method != "hash":
+        print(f"Tolerances: atol={atol}, rtol={rtol}")
 
     start_total = time.time()
-    res = compare_fast(a, b, atol, rtol, method, n_samples, n_slices)
+    results = compare_datasets(
+        a, b, method, atol, rtol, n_samples, n_slices, chunk_slices
+    )
     total_time = time.time() - start_total
 
     print(f"\n{'=' * 60}")
-    print(f"COMPARISON RESULTS ({total_time:.1f}s total):")
+    print(f"REGRESSION TEST RESULTS ({total_time:.1f}s total):")
     print(f"{'=' * 60}")
 
-    for ds, status, info in res:
+    all_identical = True
+    for ds, status, info in results:
         print(f"{ds:>22s} : {status}")
         if info and isinstance(info, str):
             print(f"{'':>25s}   {info}")
-        elif info:
-            print(f"{'':>25s}   {info}")
+        elif info and isinstance(info, list):
+            for item in info[:3]:  # Show first 3 differences
+                print(f"{'':>25s}   {item}")
+            if len(info) > 3:
+                print(f"{'':>25s}   ... and {len(info) - 3} more differences")
+
+        if status not in ["identical"]:
+            all_identical = False
+
+    # Check if data properties are identical (ignore config for pass/fail)
+    data_identical = True
+    for ds, status, info in results:
+        if ds != "config" and status not in ["identical"]:
+            data_identical = False
+            break
+
+    # Final result - only fail on data differences, not config differences
+    if data_identical:
+        result_msg = "REGRESSION TEST PASSED"
+        if not all_identical:
+            result_msg += " (config differs but data is identical)"
+    else:
+        result_msg = "REGRESSION TEST FAILED"
+
+    print(f"\n{result_msg}")
+
+    # Exit with appropriate code for CI/scripts
+    if not all_identical:
+        raise typer.Exit(1)
 
 
 if __name__ == "__main__":

--- a/velocity_modelling/tools/compare_hdf5.py
+++ b/velocity_modelling/tools/compare_hdf5.py
@@ -1,7 +1,35 @@
 #!/usr/bin/env python
-# tools/compare_hdf5_chunked.py
+"""
+compare_hdf5_sampling.py: Fast comparison of HDF5 velocity model files.
+
+This script provides several methods for comparing large HDF5 files containing seismic velocity models:
+  - Statistical sampling (recommended): samples random points for efficient comparison.
+  - Systematic slice checking: compares complete slices for thoroughness.
+  - Hash comparison: compares MD5 hashes of chunks for very fast integrity checks.
+
+Usage examples:
+    # Statistical sampling (recommended) - samples 10,000 random points
+    python compare_hdf5_sampling.py vm3_24Sep/velocity_model.h5 vm3_25Sep/velocity_model.h5 --method sample --n-samples 10000
+
+    # Systematic slice checking - checks 50 complete slices
+    python compare_hdf5_sampling.py vm3_24Sep/velocity_model.h5 vm3_25Sep/velocity_model.h5 --method slices --n-slices 50
+
+    # Hash comparison - very fast, compares MD5 hashes of chunks
+    python compare_hdf5_sampling.py vm3_24Sep/velocity_model.h5 vm3_25Sep/velocity_model.h5 --method hash
+
+For more detailed comparison, consider using h5diff:
+    # Basic comparison
+    h5diff vm3_24Sep/velocity_model.h5 vm3_25Sep/velocity_model.h5
+
+    # With tolerance
+    h5diff -d 1e-6 vm3_24Sep/velocity_model.h5 vm3_25Sep/velocity_model.h5
+
+    # Compare specific datasets
+    h5diff -d 1e-6 vm3_24Sep/velocity_model.h5 vm3_25Sep/velocity_model.h5 /properties/vp /properties/vp
+"""
 from pathlib import Path
 import argparse, h5py, numpy as np
+import time
 
 DATASETS = ["/properties/vp", "/properties/vs", "/properties/rho", "/properties/inbasin"]
 
@@ -12,28 +40,26 @@ def get_axis_mapping(cfg, shape):
     ny = int(cfg.attrs["ny"]);
     nz = int(cfg.attrs["nz"])
 
-    # If already (ny, nx, nz), no transpose needed
     if shape == (ny, nx, nz):
         return None
-
-    # Common serial layout (nz, nx, ny) -> (ny, nx, nz)
-    if shape == (nz, nx, ny):
+    elif shape == (nz, nx, ny):
         return (2, 1, 0)
-
-    # Try to infer by matching unique dim 'nz'
-    axes = list(shape)
-    try:
-        z_axis = axes.index(nz)
-        if z_axis == 0:  # (nz, ?, ?) -> (ny, nx, nz)
-            return (2, 1, 0)
-        elif z_axis == 1:  # (?, nz, ?) -> (ny, nx, nz)
-            return (0, 2, 1)
-        elif z_axis == 2:  # (?, ?, nz) -> already correct
-            return None
-    except ValueError:
-        pass
-
-    raise ValueError(f"Unrecognized shape: {shape} with nx,ny,nz={nx, ny, nz}")
+    elif shape == (ny, nz, nx):
+        return (0, 2, 1)
+    else:
+        # Try to infer
+        axes = list(shape)
+        try:
+            z_axis = axes.index(nz)
+            if z_axis == 0:
+                return (2, 1, 0)
+            elif z_axis == 1:
+                return (0, 2, 1)
+            elif z_axis == 2:
+                return None
+        except ValueError:
+            pass
+        raise ValueError(f"Unrecognized shape: {shape} with nx,ny,nz={nx, ny, nz}")
 
 
 def stats(a, b):
@@ -45,69 +71,169 @@ def stats(a, b):
     return mae, mx, rmse
 
 
-def compare_chunked(ds_a, ds_b, transpose_a, transpose_b, atol=1e-6, rtol=1e-6, chunk_size=100):
-    """Compare datasets chunk by chunk along the first axis"""
-    shape_a = ds_a.shape
-    shape_b = ds_b.shape
-
-    # After transpose, shapes should match
-    expected_shape_a = shape_a if transpose_a is None else tuple(shape_a[i] for i in transpose_a)
-    expected_shape_b = shape_b if transpose_b is None else tuple(shape_b[i] for i in transpose_b)
-
-    if expected_shape_a != expected_shape_b:
-        return False, f"shape mismatch: {expected_shape_a} vs {expected_shape_b}"
+def sample_comparison(ds_a, ds_b, transpose_a, transpose_b, target_shape,
+                      n_samples=1000, atol=1e-6, rtol=1e-6, seed=42):
+    """Compare datasets using statistical sampling"""
 
     if ds_a.dtype != ds_b.dtype:
         return False, f"dtype mismatch: {ds_a.dtype} vs {ds_b.dtype}"
 
-    # Process in chunks along first dimension
-    first_dim = expected_shape_a[0]
-    all_stats = []
-    max_diff = 0
+    ny, nx, nz = target_shape
+    np.random.seed(seed)
 
-    for start in range(0, first_dim, chunk_size):
-        end = min(start + chunk_size, first_dim)
+    print(f"  Sampling {n_samples} random points from {ny}×{nx}×{nz} array...")
+
+    # Generate random indices
+    y_indices = np.random.randint(0, ny, n_samples)
+    x_indices = np.random.randint(0, nx, n_samples)
+    z_indices = np.random.randint(0, nz, n_samples)
+
+    # Sample from both datasets
+    sample_a = []
+    sample_b = []
+
+    for i, (y, x, z) in enumerate(zip(y_indices, x_indices, z_indices)):
+        # Convert to original indices based on transpose
+        if transpose_a == (2, 1, 0):  # (nz, nx, ny) -> (ny, nx, nz)
+            orig_a = (z, x, y)
+        elif transpose_a == (0, 2, 1):  # (ny, nz, nx) -> (ny, nx, nz)
+            orig_a = (y, z, x)
+        else:  # None
+            orig_a = (y, x, z)
+
+        if transpose_b == (2, 1, 0):
+            orig_b = (z, x, y)
+        elif transpose_b == (0, 2, 1):
+            orig_b = (y, z, x)
+        else:
+            orig_b = (y, x, z)
+
+        val_a = ds_a[orig_a]
+        val_b = ds_b[orig_b]
+
+        sample_a.append(val_a)
+        sample_b.append(val_b)
+
+        if (i + 1) % 100 == 0:
+            print(f"    Sampled {i + 1}/{n_samples} points...")
+
+    sample_a = np.array(sample_a)
+    sample_b = np.array(sample_b)
+
+    # Compare samples
+    matches = np.allclose(sample_a, sample_b, atol=atol, rtol=rtol, equal_nan=True)
+    sample_stats = stats(sample_a, sample_b)
+
+    return matches, f"sample_stats: MAE={sample_stats[0]:.2e}, Max={sample_stats[1]:.2e}, RMSE={sample_stats[2]:.2e}"
+
+
+def systematic_slice_check(ds_a, ds_b, transpose_a, transpose_b, target_shape,
+                           n_slices=20, atol=1e-6, rtol=1e-6):
+    """Check a systematic sample of complete slices"""
+
+    ny, nx, nz = target_shape
+    slice_indices = np.linspace(0, ny - 1, n_slices, dtype=int)
+
+    print(f"  Checking {n_slices} systematic slices: {list(slice_indices)}")
+
+    differences = []
+
+    for i, slice_idx in enumerate(slice_indices):
+        # Load slice
+        if transpose_a == (2, 1, 0):  # (nz, nx, ny)
+            slice_a = ds_a[:, :, slice_idx]  # (nz, nx)
+            slice_a = slice_a.T  # -> (nx, nz)
+        elif transpose_a == (0, 2, 1):  # (ny, nz, nx)
+            slice_a = ds_a[slice_idx, :, :]  # (nz, nx)
+            slice_a = slice_a.T  # -> (nx, nz)
+        else:  # (ny, nx, nz)
+            slice_a = ds_a[slice_idx, :, :]  # (nx, nz)
+
+        if transpose_b == (2, 1, 0):
+            slice_b = ds_b[:, :, slice_idx]
+            slice_b = slice_b.T
+        elif transpose_b == (0, 2, 1):
+            slice_b = ds_b[slice_idx, :, :]
+            slice_b = slice_b.T
+        else:
+            slice_b = ds_b[slice_idx, :, :]
+
+        # Compare slice
+        if not np.allclose(slice_a, slice_b, atol=atol, rtol=rtol, equal_nan=True):
+            slice_stats = stats(slice_a, slice_b)
+            differences.append((slice_idx, slice_stats))
+
+        print(f"    Slice {slice_idx:4d}: {'OK' if len(differences) == i else 'DIFF'}")
+
+    if differences:
+        max_diff = max(diff[1][1] for diff in differences)  # max of max diffs
+        return False, f"{len(differences)}/{n_slices} slices differ, max_diff={max_diff:.2e}"
+    else:
+        return True, f"all {n_slices} slices match"
+
+
+def hash_comparison(ds_a, ds_b, transpose_a, transpose_b, target_shape, chunk_slices=100):
+    """Compare using hash/checksum of chunks"""
+    import hashlib
+
+    ny, nx, nz = target_shape
+
+    print(f"  Computing hashes for chunks of {chunk_slices} slices...")
+
+    hash_diffs = []
+
+    for start in range(0, ny, chunk_slices):
+        end = min(start + chunk_slices, ny)
 
         # Load chunks
-        chunk_a = ds_a[start:end]
-        chunk_b = ds_b[start:end]
+        if transpose_a == (2, 1, 0):  # (nz, nx, ny)
+            chunk_a = ds_a[:, :, start:end]
+            chunk_a = np.transpose(chunk_a, (2, 1, 0))  # -> (chunk_size, nx, nz)
+        else:
+            chunk_a = ds_a[start:end]
+            if transpose_a: chunk_a = np.transpose(chunk_a, transpose_a)
 
-        # Apply transpose if needed
-        if transpose_a is not None:
-            # Adjust transpose indices for the chunk (first dim is already selected)
-            if transpose_a == (2, 1, 0):  # (nz, nx, ny) -> (ny, nx, nz), but we selected first dim
-                # chunk shape is (chunk_size, nx, ny), we want (chunk_size, nx, ny) - no change needed
-                pass
-            elif transpose_a == (0, 2, 1):  # (ny, nz, nx) -> (ny, nx, nz)
-                chunk_a = np.transpose(chunk_a, (0, 2, 1))
+        if transpose_b == (2, 1, 0):
+            chunk_b = ds_b[:, :, start:end]
+            chunk_b = np.transpose(chunk_b, (2, 1, 0))
+        else:
+            chunk_b = ds_b[start:end]
+            if transpose_b: chunk_b = np.transpose(chunk_b, transpose_b)
 
-        if transpose_b is not None:
-            if transpose_b == (2, 1, 0):
-                pass
-            elif transpose_b == (0, 2, 1):
-                chunk_b = np.transpose(chunk_b, (0, 2, 1))
+        # Compute hashes
+        hash_a = hashlib.md5(chunk_a.tobytes()).hexdigest()
+        hash_b = hashlib.md5(chunk_b.tobytes()).hexdigest()
 
-        # Compare chunks
-        if not np.allclose(chunk_a, chunk_b, atol=atol, rtol=rtol, equal_nan=True):
-            chunk_stats = stats(chunk_a, chunk_b)
-            all_stats.append((start, end, chunk_stats))
-            max_diff = max(max_diff, chunk_stats[1])  # max absolute diff
+        if hash_a != hash_b:
+            hash_diffs.append((start, end))
 
-        print(f"  Processed slices {start:4d}-{end - 1:4d} / {first_dim - 1}")
+        print(f"    Chunk {start:4d}-{end - 1:4d}: {'SAME' if hash_a == hash_b else 'DIFF'}")
 
-    if all_stats:
-        return False, f"differences found in {len(all_stats)} chunks, max_diff={max_diff:.2e}"
+    if hash_diffs:
+        return False, f"{len(hash_diffs)} chunks have different hashes: {hash_diffs}"
     else:
-        return True, "chunks match"
+        return True, "all chunk hashes match"
 
 
-def compare(a_path: Path, b_path: Path, atol=1e-6, rtol=1e-6, chunk_size=100):
-    """Compare HDF5 files using chunked processing"""
+def compare_fast(a_path: Path, b_path: Path, atol=1e-6, rtol=1e-6,
+                 method="sample", n_samples=1000, n_slices=20):
+    """Fast comparison using various methods"""
+
+    methods = {
+        "sample": sample_comparison,
+        "slices": systematic_slice_check,
+        "hash": hash_comparison
+    }
+
+    if method not in methods:
+        raise ValueError(f"Method must be one of: {list(methods.keys())}")
+
     out = []
 
     with h5py.File(a_path, "r") as A, h5py.File(b_path, "r") as B:
         for ds_name in DATASETS:
-            print(f"\nComparing {ds_name}...")
+            print(f"\nComparing {ds_name} using {method} method...")
+            start_time = time.time()
 
             if ds_name not in A or ds_name not in B:
                 out.append((ds_name, "missing", None))
@@ -116,7 +242,6 @@ def compare(a_path: Path, b_path: Path, atol=1e-6, rtol=1e-6, chunk_size=100):
             ds_a = A[ds_name]
             ds_b = B[ds_name]
 
-            # Get config for axis mapping
             cfg_a = A.get("config")
             cfg_b = B.get("config")
 
@@ -128,26 +253,38 @@ def compare(a_path: Path, b_path: Path, atol=1e-6, rtol=1e-6, chunk_size=100):
                 transpose_a = get_axis_mapping(cfg_a, ds_a.shape)
                 transpose_b = get_axis_mapping(cfg_b, ds_b.shape)
 
+                # Determine target shape after transpose
+                nx = int(cfg_a.attrs["nx"]);
+                ny = int(cfg_a.attrs["ny"]);
+                nz = int(cfg_a.attrs["nz"])
+                target_shape = (ny, nx, nz)
+
                 print(f"  Shape A: {ds_a.shape}, transpose: {transpose_a}")
                 print(f"  Shape B: {ds_b.shape}, transpose: {transpose_b}")
 
-                is_match, info = compare_chunked(ds_a, ds_b, transpose_a, transpose_b,
-                                                 atol, rtol, chunk_size)
+                # Apply chosen method
+                if method == "sample":
+                    is_match, info = sample_comparison(ds_a, ds_b, transpose_a, transpose_b,
+                                                       target_shape, n_samples, atol, rtol)
+                elif method == "slices":
+                    is_match, info = systematic_slice_check(ds_a, ds_b, transpose_a, transpose_b,
+                                                            target_shape, n_slices, atol, rtol)
+                elif method == "hash":
+                    is_match, info = hash_comparison(ds_a, ds_b, transpose_a, transpose_b, target_shape)
 
+                elapsed = time.time() - start_time
                 status = "ok" if is_match else "differs"
-                out.append((ds_name, status, info))
+                out.append((ds_name, status, f"{info} ({elapsed:.1f}s)"))
 
             except Exception as e:
                 out.append((ds_name, "error", str(e)))
 
-        # Compare config attributes
-        print(f"\nComparing config attributes...")
+        # Config comparison (fast)
         CA, CB = A.get("config"), B.get("config")
         if CA and CB:
             keysA, keysB = set(CA.attrs), set(CB.attrs)
             common = sorted(keysA & keysB)
             skews = []
-
             for k in common:
                 va, vb = CA.attrs[k], CB.attrs[k]
                 if isinstance(va, (int, float)) and isinstance(vb, (int, float)):
@@ -156,34 +293,38 @@ def compare(a_path: Path, b_path: Path, atol=1e-6, rtol=1e-6, chunk_size=100):
                 else:
                     if str(va) != str(vb):
                         skews.append((k, va, vb))
-
-            status = "ok" if not skews else "attr-values mismatch"
-            out.append(("config", status, skews))
+            out.append(("config", "ok" if not skews else "differs", skews))
 
     return out
 
 
 if __name__ == "__main__":
-    ap = argparse.ArgumentParser(description="Compare large HDF5 files using chunked processing")
+    ap = argparse.ArgumentParser(description="Fast HDF5 comparison using sampling/hashing")
     ap.add_argument("a", type=Path, help="First HDF5 file")
     ap.add_argument("b", type=Path, help="Second HDF5 file")
+    ap.add_argument("--method", choices=["sample", "slices", "hash"], default="sample",
+                    help="Comparison method: sample (random points), slices (systematic slices), hash (chunk hashes)")
     ap.add_argument("--atol", type=float, default=1e-6, help="Absolute tolerance")
     ap.add_argument("--rtol", type=float, default=1e-6, help="Relative tolerance")
-    ap.add_argument("--chunk-size", type=int, default=100,
-                    help="Number of slices to process at once (reduce if memory issues)")
+    ap.add_argument("--n-samples", type=int, default=10000, help="Number of random samples (for sample method)")
+    ap.add_argument("--n-slices", type=int, default=50, help="Number of slices to check (for slices method)")
     args = ap.parse_args()
 
-    print(f"Comparing {args.a} vs {args.b}")
+    print(f"Fast comparing {args.a} vs {args.b}")
+    print(f"Method: {args.method}")
     print(f"Tolerances: atol={args.atol}, rtol={args.rtol}")
-    print(f"Chunk size: {args.chunk_size} slices")
 
-    res = compare(args.a, args.b, args.atol, args.rtol, args.chunk_size)
+    start_total = time.time()
+    res = compare_fast(args.a, args.b, args.atol, args.rtol, args.method, args.n_samples, args.n_slices)
+    total_time = time.time() - start_total
 
     print(f"\n{'=' * 60}")
-    print("COMPARISON RESULTS:")
+    print(f"COMPARISON RESULTS ({total_time:.1f}s total):")
     print(f"{'=' * 60}")
 
     for ds, status, info in res:
         print(f"{ds:>22s} : {status}")
-        if info and info != "chunks match":
+        if info and isinstance(info, str):
+            print(f"{'':>25s}   {info}")
+        elif info:
             print(f"{'':>25s}   {info}")

--- a/velocity_modelling/tools/compare_hdf5.py
+++ b/velocity_modelling/tools/compare_hdf5.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+# tools/compare_hdf5.py
+from pathlib import Path
+import argparse, h5py, numpy as np
+
+DATASETS = ["/properties/vp", "/properties/vs", "/properties/rho", "/properties/inbasin"]
+
+def normalize(A: h5py.File, dsname: str):
+    ds = A[dsname]
+    shape = ds.shape
+    cfg = A.get("config")
+    if cfg is None:
+        raise ValueError(f"{A.filename}: missing /config for axis mapping")
+    nx = int(cfg.attrs["nx"]); ny = int(cfg.attrs["ny"]); nz = int(cfg.attrs["nz"])
+
+    arr = np.asarray(ds[...])
+
+    # If already (ny, nx, nz), done.
+    if shape == (ny, nx, nz):
+        return arr
+
+    # Common serial layout (nz, nx, ny)
+    if shape == (nz, nx, ny):
+        # permute to (ny, nx, nz)
+        return np.transpose(arr, (2,1,0))
+
+    # Your earlier parallel layout (ny, nx, nz)
+    if shape == (ny, nx, nz):
+        return arr
+
+    # Fallback: try to infer by matching unique dim 'nz'
+    axes = list(shape)
+    try:
+        z_axis = axes.index(nz)
+        # remaining two axes should be nx, ny (equal here, so we assume order (ny, nx, nz))
+        if z_axis == 0:
+            return np.transpose(arr, (2,1,0))
+        elif z_axis == 1:
+            return np.transpose(arr, (0,2,1))
+        elif z_axis == 2:
+            return arr
+    except ValueError:
+        pass
+    raise ValueError(f"Unrecognized shape for {dsname}: {shape} with nx,ny,nz={nx,ny,nz}")
+
+def stats(a, b):
+    d = a - b
+    mae = float(np.mean(np.abs(d)))
+    mx  = float(np.max(np.abs(d)))
+    rmse= float(np.sqrt(np.mean(d*d)))
+    return mae, mx, rmse
+
+def compare(a_path: Path, b_path: Path, atol=1e-6, rtol=1e-6, per_slice=False):
+    out = []
+    with h5py.File(a_path, "r") as A, h5py.File(b_path, "r") as B:
+        for ds in DATASETS:
+            if ds not in A or ds not in B:
+                out.append((ds, "missing", None)); continue
+            x = normalize(A, ds)  # -> (ny, nx, nz)
+            y = normalize(B, ds)
+            if x.shape != y.shape or x.dtype != y.dtype:
+                out.append((ds, "shape/dtype mismatch", (x.shape, y.shape, str(x.dtype), str(y.dtype))))
+                continue
+            if per_slice:
+                ny = x.shape[0]; diffs=[]
+                for j in range(ny):
+                    a = x[j]; b = y[j]
+                    if not np.allclose(a, b, atol=atol, rtol=rtol, equal_nan=True):
+                        diffs.append((j,)+stats(a,b))
+                out.append((ds, "per-slice", diffs))
+            else:
+                ok = np.allclose(x, y, atol=atol, rtol=rtol, equal_nan=True)
+                out.append((ds, "ok" if ok else "differs", None if ok else stats(x,y)))
+
+        # compare selected config attrs
+        CA, CB = A.get("config"), B.get("config")
+        if CA and CB:
+            keysA, keysB = set(CA.attrs), set(CB.attrs)
+            # tolerate extra keys, only assert common ones
+            common = sorted(keysA & keysB)
+            skews=[]
+            for k in common:
+                va, vb = CA.attrs[k], CB.attrs[k]
+                if isinstance(va,(int,float)) and isinstance(vb,(int,float)):
+                    if not np.isclose(va, vb, atol=atol, rtol=rtol):
+                        skews.append((k, va, vb))
+                else:
+                    if str(va) != str(vb):
+                        skews.append((k, va, vb))
+            out.append(("config", "ok" if not skews else "attr-values mismatch", skews))
+    return out
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("a", type=Path)
+    ap.add_argument("b", type=Path)
+    ap.add_argument("--atol", type=float, default=1e-6)
+    ap.add_argument("--rtol", type=float, default=1e-6)
+    ap.add_argument("--per-slice", action="store_true")
+    args = ap.parse_args()
+    res = compare(args.a, args.b, args.atol, args.rtol, args.per_slice)
+    for ds, status, info in res:
+        print(f"{ds:>22s} : {status}", "" if info is None else info)

--- a/velocity_modelling/tools/convert_hdf5_to_emod3d.py
+++ b/velocity_modelling/tools/convert_hdf5_to_emod3d.py
@@ -1,37 +1,181 @@
 #!/usr/bin/env python
-# tools/convert_hdf5_to_emod3d.py
+"""
+Convert HDF5 velocity model files to EMOD3D binary format.
+
+This script converts HDF5 velocity model files (produced by hdf5.py) to the binary
+format expected by EMOD3D, producing the same output files as emod3d.py:
+- vp3dfile.p (P-wave velocities)
+- vs3dfile.s (S-wave velocities)
+- rho3dfile.d (densities)
+- in_basin_mask.b (basin membership mask)
+"""
+
+import argparse
+import struct
+import sys
+import time
 from pathlib import Path
-import argparse, h5py, numpy as np
+from typing import Optional
 
-def main(src_h5: Path, out_dir: Path, zero_pad: int = 5):
+import h5py
+import numpy as np
+from tqdm import tqdm
+
+
+def convert_hdf5_to_emod3d(
+    src_h5: Path,
+    out_dir: Path,
+    min_vs: Optional[float] = None
+) -> None:
+    """
+    Convert HDF5 velocity model to EMOD3D binary format.
+
+    The key insight from emod3d.py is that it writes data as:
+    - For each y-slice (latitude index j from 0 to ny-1):
+      - Extract partial_global_qualities which has shape (nx, nz)
+      - Apply: partial_global_qualities.vp.T.flatten()
+      - This creates a flattened array where z varies fastest, then x
+
+    The HDF5 format stores data as (nz, ny, nx), and hdf5.py already
+    transposes the data before storing: (nx, nz) -> (nz, nx)
+    So when we extract slice [:, j, :] we get (nz, nx) which is exactly
+    what emod3d.py produces with .T.flatten()
+
+    Parameters
+    ----------
+    src_h5 : Path
+        Path to input HDF5 file.
+    out_dir : Path
+        Output directory for binary files.
+    min_vs : float, optional
+        Minimum Vs value to enforce. If None, uses value from HDF5 metadata.
+    """
+    start_time = time.time()
+
     out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Determine endianness and format string (match emod3d.py exactly)
+    endianness = sys.byteorder
+    endian_format = "<" if endianness == "little" else ">"
+
+    # Output file paths (match emod3d.py exactly)
+    vp3dfile = out_dir / "vp3dfile.p"
+    vs3dfile = out_dir / "vs3dfile.s"
+    rho3dfile = out_dir / "rho3dfile.d"
+    in_basin_mask_file = out_dir / "in_basin_mask.b"
+
     with h5py.File(src_h5, "r") as f:
-        vp  = f["/properties/vp"]          # (nz, nx, ny)
-        vs  = f["/properties/vs"]
-        rho = f["/properties/rho"]
-        inb = f["/properties/inbasin"]
-        nz, nx, ny = vp.shape
+        # Read data arrays - HDF5 format is (nz, ny, nx)
+        vp_full = np.array(f["/properties/vp"])     # (nz, ny, nx)
+        vs_full = np.array(f["/properties/vs"])     # (nz, ny, nx)
+        rho_full = np.array(f["/properties/rho"])   # (nz, ny, nx)
+        inbasin_full = np.array(f["/properties/inbasin"])  # (nz, ny, nx)
 
-        for j in range(ny):
-            # Extract (nz, nx) then transpose to (nx, nz) to match your EMOD3D writer
-            vp_j  = np.asarray(vp[:,  :, j]).T
-            vs_j  = np.asarray(vs[:,  :, j]).T
-            rho_j = np.asarray(rho[:, :, j]).T
-            inb_j = np.asarray(inb[:, :, j]).T
+        nz, ny, nx = vp_full.shape
 
-            path = out_dir / f"slice_{j:0{zero_pad}d}.txt"
-            with path.open("w") as fp:
-                fp.write(f"# slice {j}\n# nx={nx} nz={nz}\n")
-                # Example row format; mirror emod3d.py if needed
-                for x in range(nx):
-                    row = " ".join(f"{vp_j[x,z]:.6g},{vs_j[x,z]:.6g},{rho_j[x,z]:.6g},{int(inb_j[x,z])}"
-                                   for z in range(nz))
-                    fp.write(row + "\n")
+        # Get min_vs from file metadata if not provided
+        if min_vs is None:
+            min_vs = f["/properties/vs"].attrs.get("min_value_enforced", 0.0)
+
+        print(f"Converting HDF5 model with shape (nz={nz}, ny={ny}, nx={nx})")
+        print(f"Applying minimum Vs constraint: {min_vs} km/s")
+
+    # Remove any existing files (match emod3d.py behavior)
+    for filepath in [vp3dfile, vs3dfile, rho3dfile, in_basin_mask_file]:
+        filepath.unlink(missing_ok=True)
+
+    # Process each y-slice (latitude) to exactly match emod3d.py write pattern
+    with open(vp3dfile, "wb") as fvp, \
+         open(vs3dfile, "wb") as fvs, \
+         open(rho3dfile, "wb") as frho, \
+         open(in_basin_mask_file, "wb") as fmask:
+
+        for j in tqdm(range(ny), desc="Processing y-slices", unit="slice"):
+            # Extract slice for this y-index from HDF5: (nz, ny, nx) -> (nz, nx)
+            # The hdf5.py already stored the data transposed, so this gives us
+            # exactly what emod3d.py produces with .T.flatten()
+            vp_slice = vp_full[:, j, :]      # Shape: (nz, nx)
+            vs_slice = vs_full[:, j, :]      # Shape: (nz, nx)
+            rho_slice = rho_full[:, j, :]    # Shape: (nz, nx)
+            inb_slice = inbasin_full[:, j, :] # Shape: (nz, nx)
+
+            # Apply minimum Vs constraint (match emod3d.py exactly)
+            vs_slice = np.maximum(vs_slice, min_vs)
+
+            # The HDF5 slice already has the correct layout from hdf5.py
+            # Just flatten directly - no need for additional transposing
+            vp_flat = vp_slice.flatten()   # (nz, nx) -> flat
+            vs_flat = vs_slice.flatten()   # (nz, nx) -> flat
+            rho_flat = rho_slice.flatten() # (nz, nx) -> flat
+            inb_flat = inb_slice.flatten() # (nz, nx) -> flat
+
+            # Convert inbasin to the same dtype as used in emod3d.py
+            # emod3d.py: inbasin.astype(vp.dtype) where vp.dtype is float32
+            inb_flat = inb_flat.astype(np.float32)
+
+            # Debug: print first few values for the first slice
+            if j == 0:
+                print(f"\nFirst slice debug - first 10 values:")
+                print(f"  vp:  {vp_flat[:10]}")
+                print(f"  vs:  {vs_flat[:10]}")
+                print(f"  rho: {rho_flat[:10]}")
+
+            # Pack binary data with appropriate endianness (match emod3d.py exactly)
+            vp_data = struct.pack(f"{endian_format}{len(vp_flat)}f", *vp_flat)
+            vs_data = struct.pack(f"{endian_format}{len(vs_flat)}f", *vs_flat)
+            rho_data = struct.pack(f"{endian_format}{len(rho_flat)}f", *rho_flat)
+            inb_data = struct.pack(f"{endian_format}{len(inb_flat)}f", *inb_flat)
+
+            # Write to binary files (append mode matches emod3d.py)
+            fvp.write(vp_data)
+            fvs.write(vs_data)
+            frho.write(rho_data)
+            fmask.write(inb_data)
+
+    end_time = time.time()
+    processing_time = end_time - start_time
+
+    print(f"✅ Conversion complete!")
+    print(f"   Created: {vp3dfile}")
+    print(f"   Created: {vs3dfile}")
+    print(f"   Created: {rho3dfile}")
+    print(f"   Created: {in_basin_mask_file}")
+    print(f"   Processing time: {processing_time:.2f} seconds")
+
+
+def main() -> None:
+    """Main entry point for the script."""
+    parser = argparse.ArgumentParser(
+        description="Convert HDF5 velocity model to EMOD3D binary format"
+    )
+    parser.add_argument(
+        "src_h5",
+        type=Path,
+        help="Path to input HDF5 file"
+    )
+    parser.add_argument(
+        "out_dir",
+        type=Path,
+        help="Output directory for binary files"
+    )
+    parser.add_argument(
+        "--min-vs",
+        type=float,
+        help="Minimum Vs value to enforce (km/s). If not specified, uses value from HDF5 metadata."
+    )
+
+    args = parser.parse_args()
+
+    if not args.src_h5.exists():
+        print(f"❌ Error: Input file {args.src_h5} does not exist")
+        sys.exit(1)
+
+    try:
+        convert_hdf5_to_emod3d(args.src_h5, args.out_dir, args.min_vs)
+    except Exception as e:
+        print(f"❌ Error during conversion: {e}")
+        sys.exit(1)
+
 
 if __name__ == "__main__":
-    ap = argparse.ArgumentParser()
-    ap.add_argument("src_h5", type=Path)
-    ap.add_argument("out_dir", type=Path)
-    ap.add_argument("--zero-pad", type=int, default=5)
-    args = ap.parse_args()
-    main(args.src_h5, args.out_dir, args.zero_pad)
+    main()

--- a/velocity_modelling/tools/convert_hdf5_to_emod3d.py
+++ b/velocity_modelling/tools/convert_hdf5_to_emod3d.py
@@ -14,7 +14,7 @@ import struct
 import sys
 import time
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated
 
 import h5py
 import numpy as np
@@ -26,7 +26,9 @@ app = typer.Typer(pretty_exceptions_enable=False)
 
 
 def convert_hdf5_to_emod3d(
-        src_h5: Path, out_dir: Path, min_vs: Optional[float] = None
+        src_h5: Path,
+        out_dir: Path,
+        min_vs: float | None = None
 ) -> None:
     """
     Convert HDF5 velocity model to EMOD3D binary format.
@@ -45,11 +47,28 @@ def convert_hdf5_to_emod3d(
     Parameters
     ----------
     src_h5 : Path
-        Path to input HDF5 file.
+        Path to input HDF5 file containing velocity model data.
     out_dir : Path
-        Output directory for binary files.
-    min_vs : float, optional
-        Minimum Vs value to enforce. If None, uses value from HDF5 metadata.
+        Output directory where binary files will be written.
+    min_vs : float | None, optional
+        Minimum Vs value to enforce in km/s. If None, uses value from HDF5 metadata.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the input HDF5 file does not exist.
+    KeyError
+        If required datasets are missing from the HDF5 file.
+    ValueError
+        If data shapes or types are invalid.
+    OSError
+        If there are issues creating output directory or writing binary files.
+
+    Notes
+    -----
+    This function creates binary files that exactly match the output format
+    of the original emod3d.py writer, ensuring compatibility with EMOD3D
+    simulation software.
     """
     start_time = time.time()
 
@@ -147,20 +166,61 @@ def convert_hdf5_to_emod3d(
 
 @cli.from_docstring(app)
 def convert_hdf5_to_emod3d_main(
-        src_h5: Annotated[Path, typer.Argument(exists=True, dir_okay=False, help="Path to input HDF5 file")],
-        out_dir: Annotated[Path, typer.Argument(help="Output directory for binary files")],
-        min_vs: Annotated[Optional[float], typer.Option(
-            help="Minimum Vs value to enforce (km/s). If not specified, uses value from HDF5 metadata.")] = None,
+        src_h5: Annotated[Path, typer.Argument(
+            exists=True,
+            dir_okay=False,
+        )],
+        out_dir: Annotated[Path, typer.Argument(
+            file_okay=False,
+            writable=True,
+        )],
+        min_vs: float | None = None,
 ) -> None:
     """
     Convert HDF5 velocity model to EMOD3D binary format.
 
-    Converts HDF5 velocity model files (produced by hdf5.py) to the binary
-    format expected by EMOD3D, producing the same output files as emod3d.py:
-    - vp3dfile.p (P-wave velocities)
-    - vs3dfile.s (S-wave velocities)
-    - rho3dfile.d (densities)
-    - in_basin_mask.b (basin membership mask)
+    This command-line interface converts HDF5 velocity model files (produced by hdf5.py)
+    to the binary format expected by EMOD3D, producing the same output files as emod3d.py.
+
+    The conversion process reads velocity model data from the HDF5 file and writes it
+    in the specific binary format required by EMOD3D simulations, maintaining exact
+    compatibility with the original emod3d.py writer.
+
+    Parameters
+    ----------
+    src_h5 : Path
+        Path to the input HDF5 file containing velocity model data.
+        Must exist and be a valid HDF5 file with the expected datasets.
+    out_dir : Path
+        Output directory where the binary files will be written.
+        Will be created if it doesn't exist.
+    min_vs : float | None, optional
+        Minimum S-wave velocity value to enforce in km/s.
+        If not specified, uses the value stored in the HDF5 metadata.
+
+    Raises
+    ------
+    typer.Exit
+        Exits with code 1 if conversion fails due to file errors,
+        invalid data, or other processing issues.
+
+    Examples
+    --------
+    Convert with default minimum Vs from HDF5 metadata:
+
+    >>> convert_hdf5_to_emod3d_main(Path("model.h5"), Path("output"))
+
+    Convert with custom minimum Vs constraint:
+
+    >>> convert_hdf5_to_emod3d_main(Path("model.h5"), Path("output"), min_vs=0.5)
+
+    Notes
+    -----
+    The output binary files are:
+    - vp3dfile.p: P-wave velocities
+    - vs3dfile.s: S-wave velocities
+    - rho3dfile.d: Densities
+    - in_basin_mask.b: Basin membership mask
     """
     try:
         convert_hdf5_to_emod3d(src_h5, out_dir, min_vs)

--- a/velocity_modelling/tools/convert_hdf5_to_emod3d.py
+++ b/velocity_modelling/tools/convert_hdf5_to_emod3d.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# tools/convert_hdf5_to_emod3d.py
+from pathlib import Path
+import argparse, h5py, numpy as np
+
+def main(src_h5: Path, out_dir: Path, zero_pad: int = 5):
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with h5py.File(src_h5, "r") as f:
+        vp  = f["/properties/vp"]          # (nz, nx, ny)
+        vs  = f["/properties/vs"]
+        rho = f["/properties/rho"]
+        inb = f["/properties/inbasin"]
+        nz, nx, ny = vp.shape
+
+        for j in range(ny):
+            # Extract (nz, nx) then transpose to (nx, nz) to match your EMOD3D writer
+            vp_j  = np.asarray(vp[:,  :, j]).T
+            vs_j  = np.asarray(vs[:,  :, j]).T
+            rho_j = np.asarray(rho[:, :, j]).T
+            inb_j = np.asarray(inb[:, :, j]).T
+
+            path = out_dir / f"slice_{j:0{zero_pad}d}.txt"
+            with path.open("w") as fp:
+                fp.write(f"# slice {j}\n# nx={nx} nz={nz}\n")
+                # Example row format; mirror emod3d.py if needed
+                for x in range(nx):
+                    row = " ".join(f"{vp_j[x,z]:.6g},{vs_j[x,z]:.6g},{rho_j[x,z]:.6g},{int(inb_j[x,z])}"
+                                   for z in range(nz))
+                    fp.write(row + "\n")
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("src_h5", type=Path)
+    ap.add_argument("out_dir", type=Path)
+    ap.add_argument("--zero-pad", type=int, default=5)
+    args = ap.parse_args()
+    main(args.src_h5, args.out_dir, args.zero_pad)

--- a/velocity_modelling/tools/convert_hdf5_to_emod3d.py
+++ b/velocity_modelling/tools/convert_hdf5_to_emod3d.py
@@ -19,16 +19,15 @@ from typing import Annotated
 import h5py
 import numpy as np
 import typer
-from qcore import cli
 from tqdm import tqdm
+
+from qcore import cli
 
 app = typer.Typer(pretty_exceptions_enable=False)
 
 
 def convert_hdf5_to_emod3d(
-        src_h5: Path,
-        out_dir: Path,
-        min_vs: float | None = None
+    src_h5: Path, out_dir: Path, min_vs: float | None = None
 ) -> None:
     """
     Convert HDF5 velocity model to EMOD3D binary format.
@@ -166,15 +165,21 @@ def convert_hdf5_to_emod3d(
 
 @cli.from_docstring(app)
 def convert_hdf5_to_emod3d_main(
-        src_h5: Annotated[Path, typer.Argument(
+    src_h5: Annotated[
+        Path,
+        typer.Argument(
             exists=True,
             dir_okay=False,
-        )],
-        out_dir: Annotated[Path, typer.Argument(
+        ),
+    ],
+    out_dir: Annotated[
+        Path,
+        typer.Argument(
             file_okay=False,
             writable=True,
-        )],
-        min_vs: float | None = None,
+        ),
+    ],
+    min_vs: float | None = None,
 ) -> None:
     """
     Convert HDF5 velocity model to EMOD3D binary format.

--- a/velocity_modelling/write/hdf5.py
+++ b/velocity_modelling/write/hdf5.py
@@ -5,7 +5,6 @@ This module provides functions to write the velocity model data to HDF5 format f
 HDF5 (Hierarchical Data Format version 5) is an efficient binary format for storing large
 scientific datasets with metadata.
 """
-
 import datetime
 import logging
 from logging import Logger
@@ -96,6 +95,274 @@ def create_xdmf_file(hdf5_file: Path, vm_params: dict, logger: logging.Logger) -
         logger.log(logging.ERROR, f"Error creating XDMF file: {e}")
         raise RuntimeError(f"Failed to create XDMF file: {e}")
 
+# --- Cache for one open file per out_dir (single-writer process) ---
+_FILE_CACHE = {}  # key: resolved out_dir -> (h5py.File, dict_dsets)
+_RDCC_NBYTES = 128 * 1024 * 1024  # 128MB file-level raw chunk cache
+_RDCC_NSLOTS = 1_000_003          # large prime, reduces hash collisions
+_RDCC_W0     = 0.75               # preemption policy
+
+def _ensure_open(out_dir: Path, vm_params: dict, nx: int, ny: int, nz: int, logger: Logger):
+    """
+    Open/create velocity_model.h5 once and return (f, dsets).
+    dsets: {"vp":ds, "vs":ds, "rho":ds, "inbasin":ds, "lat":ds, "lon":ds}
+    """
+    from pathlib import Path as _P
+    key = str(_P(out_dir).resolve())
+    cached = _FILE_CACHE.get(key)
+    if cached:
+        return cached
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    hdf5_file = out_dir / "velocity_model.h5"
+
+    # Open once with tuned raw data chunk cache
+    f = h5py.File(
+        hdf5_file, "w", libver="latest",
+        rdcc_nbytes=_RDCC_NBYTES, rdcc_nslots=_RDCC_NSLOTS, rdcc_w0=_RDCC_W0
+    )
+
+    # File-level attrs
+    f.attrs.update(
+        {
+            "total_y_slices": ny,
+            "format_version": "1.0",
+            "creation_date": datetime.datetime.now().isoformat(),
+        }
+    )
+
+    # Config group (stringify exotic values just like your current code)
+    config_group = f.create_group("config")
+    config_group.attrs.update(
+        {
+            k: (v.name if hasattr(v, "name") else v.value if hasattr(v, "value") else str(v))
+            for k, v in vm_params.items()
+        }
+    )
+    config_group.attrs["config_string"] = "\n".join(f"{k.upper()}={v}" for k, v in vm_params.items())
+
+    # Mesh + properties groups
+    mesh_group = f.create_group("mesh")
+    mesh_group.create_dataset("x", data=np.arange(nx, dtype=np.int32))
+    mesh_group.create_dataset("y", data=np.arange(ny, dtype=np.int32))
+    mesh_group.create_dataset("z", data=np.arange(nz, dtype=np.int32))
+    d_lat = mesh_group.create_dataset("lat", shape=(nx, ny), dtype="f8")
+    d_lon = mesh_group.create_dataset("lon", shape=(nx, ny), dtype="f8")
+
+    props = f.create_group("properties")
+
+    # Your layout is (nz, ny, nx) (z, y, x) for ParaView; write whole y-slice fast:
+    shape  = (nz, ny, nx)
+    chunks = (nz, 1,  nx)  # one complete y-slice per chunk  ← key for fast [:, j, :] writes
+
+    d_vp  = props.create_dataset("vp",      shape=shape, dtype="f4", chunks=chunks)
+    d_vs  = props.create_dataset("vs",      shape=shape, dtype="f4", chunks=chunks)
+    d_rho = props.create_dataset("rho",     shape=shape, dtype="f4", chunks=chunks)
+    d_inb = props.create_dataset("inbasin", shape=shape, dtype="i1", chunks=chunks)
+    d_vp.attrs["units"] = "km/s"
+    d_vs.attrs.update({"units": "km/s", "min_value_enforced": vm_params.get("min_vs", 0.0)})
+    d_rho.attrs["units"] = "g/cm^3"
+
+    dsets = {"vp": d_vp, "vs": d_vs, "rho": d_rho, "inbasin": d_inb, "lat": d_lat, "lon": d_lon}
+    _FILE_CACHE[key] = (f, dsets)
+
+    # Close automatically when the process exits
+    import atexit
+    def _close_once(k=key):
+        tup = _FILE_CACHE.pop(k, None)
+        if tup:
+            try: tup[0].close()
+            except Exception: pass
+    atexit.register(_close_once)
+
+    if logger:
+        logger.log(
+            logging.DEBUG,
+            f"[hdf5] opened {hdf5_file} shape={shape} chunks={chunks} rdcc={_RDCC_NBYTES//(1024*1024)}MB",
+        )
+    return _FILE_CACHE[key]
+
+def _close_cache(out_dir: Optional[Path] = None):
+    """Optional manual close (useful in tests/resets)."""
+    if out_dir is None:
+        keys = list(_FILE_CACHE.keys())
+    else:
+        keys = [str(Path(out_dir).resolve())]
+    for k in keys:
+        tup = _FILE_CACHE.pop(k, None)
+        if tup:
+            try: tup[0].close()
+            except Exception: pass
+
+
+# def write_global_qualities(
+#     out_dir: Path,
+#     partial_global_mesh: PartialGlobalMesh,
+#     partial_global_qualities: PartialGlobalQualities,
+#     lat_ind: int,
+#     vm_params: dict,
+#     logger: Optional[Logger] = None,
+# ) -> None:
+#     """
+#     Write a latitude slice of velocity data to a single consolidated HDF5 file.
+#
+#     For the first slice (lat_ind=0), this creates the file and initializes the structure.
+#     For subsequent slices, it adds data to the existing file.
+#
+#     Parameters
+#     ----------
+#     out_dir : Path
+#         Path to the output directory where the HDF5 file will be written.
+#     partial_global_mesh : PartialGlobalMesh
+#         Mesh data for the current latitude slice.
+#     partial_global_qualities : PartialGlobalQualities
+#         Velocity and density data for the current latitude slice.
+#     lat_ind : int
+#         Latitude index to determine the write mode (write or append).
+#     vm_params : dict
+#         Dictionary containing velocity model parameters from nzcvm.cfg.
+#     logger : Logger, optional
+#         Logger instance for logging messages.
+#
+#     Raises
+#     ------
+#     OSError
+#         If the HDF5 file cannot be written due to permissions or disk issues.
+#     """
+#     if logger is None:
+#         logger = Logger("xdmf")
+#
+#     # Output filename - single file for all slices
+#     hdf5_file = out_dir / "velocity_model.h5"
+#     vs_data = np.copy(partial_global_qualities.vs)
+#     min_vs = vm_params.get("min_vs", 0.0)
+#     vs_data[vs_data < min_vs] = min_vs
+#
+#     # ny is the number of slices in the y direction, but what we are processing here is a single slice
+#     # along y (=lat if not-rotated) axis, so we need to get the total number of slices from the vm_params
+#
+#     try:
+#         ny = vm_params["ny"]
+#     except KeyError:
+#         logger.log(
+#             logging.ERROR,
+#             "Missing 'ny' key in vm_params. Ensure the velocity model parameters are correctly set.",
+#         )
+#         raise KeyError("Missing 'ny' key in vm_params.")
+#
+#     nx, nz = partial_global_qualities.vp.shape
+#
+#     # If first slice, create the file and initialize structure
+#     if lat_ind == 0:
+#         try:
+#             with h5py.File(hdf5_file, "w") as f:
+#                 f.attrs.update(
+#                     {
+#                         "total_y_slices": ny,
+#                         "format_version": "1.0",
+#                         "creation_date": datetime.datetime.now().isoformat(),
+#                     }
+#                 )
+#
+#                 config_group = f.create_group("config")
+#                 config_group.attrs.update(
+#                     {
+#                         k: (
+#                             v.name
+#                             if hasattr(v, "name")
+#                             else v.value
+#                             if hasattr(v, "value")
+#                             else str(v)
+#                         )
+#                         for k, v in vm_params.items()
+#                     }
+#                 )
+#                 config_group.attrs["config_string"] = "\n".join(
+#                     f"{k.upper()}={v}" for k, v in vm_params.items()
+#                 )
+#
+#                 mesh_group = f.create_group("mesh")
+#                 mesh_group.create_dataset("x", data=np.arange(nx, dtype=np.int32))
+#                 mesh_group.create_dataset("y", data=np.arange(ny, dtype=np.int32))
+#                 mesh_group.create_dataset(
+#                     "z", data=np.arange(nz, dtype=np.int32)
+#                 )  # depth 0 is the top, the higher z is the deeper
+#                 mesh_group.create_dataset("lat", shape=(nx, ny), dtype="f8")
+#                 mesh_group.create_dataset("lon", shape=(nx, ny), dtype="f8")
+#
+#                 props = f.create_group("properties")
+#
+#                 # Create datasets with shape (nz, ny, nx): Paraview demands this order
+#                 shape = (nz, ny, nx)
+#
+#                 logger.log(
+#                     logging.DEBUG,
+#                     f"Creating datasets with shape (nz={nz}, ny={ny}, nx={nx})",
+#                 )
+#                 # props.create_dataset("vp", shape=shape, dtype="f4", compression="gzip")
+#                 # props.create_dataset("vs", shape=shape, dtype="f4", compression="gzip")
+#                 # props.create_dataset("rho", shape=shape, dtype="f4", compression="gzip")
+#                 # props.create_dataset(
+#                 #     "inbasin", shape=shape, dtype="i1", compression="gzip"
+#                 # )
+#
+#                 props.create_dataset("vp", shape=shape, dtype="f4")
+#                 props.create_dataset("vs", shape=shape, dtype="f4")
+#                 props.create_dataset("rho", shape=shape, dtype="f4")
+#                 props.create_dataset(
+#                     "inbasin", shape=shape, dtype="i1")
+#
+#                 # Add metadata
+#                 props["vp"].attrs["units"] = "km/s"
+#                 props["vs"].attrs.update(
+#                     {"units": "km/s", "min_value_enforced": min_vs}
+#                 )
+#                 props["rho"].attrs["units"] = "g/cm^3"
+#         except OSError as e:
+#             logger.log(logging.ERROR, f"Failed to create HDF5 file {hdf5_file}: {e}")
+#             raise OSError(f"Failed to create HDF5 file {hdf5_file}: {str(e)}")
+#
+#     try:
+#         with h5py.File(hdf5_file, "r+") as f:
+#             f["mesh/lat"][:, lat_ind] = partial_global_mesh.lat
+#             f["mesh/lon"][:, lat_ind] = partial_global_mesh.lon
+#
+#             # Write property data for this slice to make this Paraview compatible
+#             # partial_global_qualities.vp is (nx, nz), need to transpose to (nz, nx) for (z, x)
+#             # Dataset is (nz, ny, nx), so [:, lat_ind, :] expects (nz, nx)
+#             vp = partial_global_qualities.vp.T
+#             vs = vs_data.T
+#             rho = partial_global_qualities.rho.T
+#             inbasin = partial_global_qualities.inbasin.T
+#
+#             expected = (nz, nx)
+#             if vp.shape != expected:
+#                 logger.log(
+#                     logging.ERROR,
+#                     f"Shape mismatch: vp has shape {vp.shape}, expected {expected}",
+#                 )
+#                 raise ValueError(f"Shape mismatch: got {vp.shape}, expected {expected}")
+#
+#             f["properties/vp"][:, lat_ind, :] = vp
+#             f["properties/vs"][:, lat_ind, :] = vs
+#             f["properties/rho"][:, lat_ind, :] = rho
+#             f["properties/inbasin"][:, lat_ind, :] = inbasin
+#
+#             f.attrs["last_slice_written"] = lat_ind
+#     except OSError as e:
+#         logger.log(logging.ERROR, f"Failed to update HDF5 file {hdf5_file}: {e}")
+#         raise OSError(f"Failed to update HDF5 file {hdf5_file}: {str(e)}")
+#     except Exception as e:
+#         if isinstance(e, (SystemExit, KeyboardInterrupt)):
+#             raise  # Re-raise critical exceptions
+#         logger.log(logging.ERROR, f"Error writing to HDF5 file {hdf5_file}: {e}")
+#         raise RuntimeError(f"Error writing to HDF5 file {hdf5_file}: {str(e)}")
+#
+#     # After writing all slices, create the XDMF file
+#     if lat_ind == ny - 1:
+#         create_xdmf_file(hdf5_file, vm_params, logger)
+#         logger.log(logging.INFO, "HDF5 model complete with ParaView compatibility")
+
+
 def write_global_qualities(
     out_dir: Path,
     partial_global_mesh: PartialGlobalMesh,
@@ -104,162 +371,51 @@ def write_global_qualities(
     vm_params: dict,
     logger: Optional[Logger] = None,
 ) -> None:
-    """
-    Write a latitude slice of velocity data to a single consolidated HDF5 file.
-
-    For the first slice (lat_ind=0), this creates the file and initializes the structure.
-    For subsequent slices, it adds data to the existing file.
-
-    Parameters
-    ----------
-    out_dir : Path
-        Path to the output directory where the HDF5 file will be written.
-    partial_global_mesh : PartialGlobalMesh
-        Mesh data for the current latitude slice.
-    partial_global_qualities : PartialGlobalQualities
-        Velocity and density data for the current latitude slice.
-    lat_ind : int
-        Latitude index to determine the write mode (write or append).
-    vm_params : dict
-        Dictionary containing velocity model parameters from nzcvm.cfg.
-    logger : Logger, optional
-        Logger instance for logging messages.
-
-    Raises
-    ------
-    OSError
-        If the HDF5 file cannot be written due to permissions or disk issues.
-    """
     if logger is None:
-        logger = Logger("xdmf")
+        logger = logging.getLogger("hdf5")
 
-    # Output filename - single file for all slices
-    hdf5_file = out_dir / "velocity_model.h5"
+    # Enforce min_vs before writing
     vs_data = np.copy(partial_global_qualities.vs)
     min_vs = vm_params.get("min_vs", 0.0)
     vs_data[vs_data < min_vs] = min_vs
 
-    # ny is the number of slices in the y direction, but what we are processing here is a single slice
-    # along y (=lat if not-rotated) axis, so we need to get the total number of slices from the vm_params
-
-    try:
-        ny = vm_params["ny"]
-    except KeyError:
-        logger.log(
-            logging.ERROR,
-            "Missing 'ny' key in vm_params. Ensure the velocity model parameters are correctly set.",
-        )
-        raise KeyError("Missing 'ny' key in vm_params.")
-
+    # nx, ny, nz
     nx, nz = partial_global_qualities.vp.shape
-
-    # If first slice, create the file and initialize structure
-    if lat_ind == 0:
-        try:
-            with h5py.File(hdf5_file, "w") as f:
-                f.attrs.update(
-                    {
-                        "total_y_slices": ny,
-                        "format_version": "1.0",
-                        "creation_date": datetime.datetime.now().isoformat(),
-                    }
-                )
-
-                config_group = f.create_group("config")
-                config_group.attrs.update(
-                    {
-                        k: (
-                            v.name
-                            if hasattr(v, "name")
-                            else v.value
-                            if hasattr(v, "value")
-                            else str(v)
-                        )
-                        for k, v in vm_params.items()
-                    }
-                )
-                config_group.attrs["config_string"] = "\n".join(
-                    f"{k.upper()}={v}" for k, v in vm_params.items()
-                )
-
-                mesh_group = f.create_group("mesh")
-                mesh_group.create_dataset("x", data=np.arange(nx, dtype=np.int32))
-                mesh_group.create_dataset("y", data=np.arange(ny, dtype=np.int32))
-                mesh_group.create_dataset(
-                    "z", data=np.arange(nz, dtype=np.int32)
-                )  # depth 0 is the top, the higher z is the deeper
-                mesh_group.create_dataset("lat", shape=(nx, ny), dtype="f8")
-                mesh_group.create_dataset("lon", shape=(nx, ny), dtype="f8")
-
-                props = f.create_group("properties")
-
-                # Create datasets with shape (nz, ny, nx): Paraview demands this order
-                shape = (nz, ny, nx)
-
-                logger.log(
-                    logging.DEBUG,
-                    f"Creating datasets with shape (nz={nz}, ny={ny}, nx={nx})",
-                )
-                # props.create_dataset("vp", shape=shape, dtype="f4", compression="gzip")
-                # props.create_dataset("vs", shape=shape, dtype="f4", compression="gzip")
-                # props.create_dataset("rho", shape=shape, dtype="f4", compression="gzip")
-                # props.create_dataset(
-                #     "inbasin", shape=shape, dtype="i1", compression="gzip"
-                # )
-
-                props.create_dataset("vp", shape=shape, dtype="f4")
-                props.create_dataset("vs", shape=shape, dtype="f4")
-                props.create_dataset("rho", shape=shape, dtype="f4")
-                props.create_dataset(
-                    "inbasin", shape=shape, dtype="i1")
-
-                # Add metadata
-                props["vp"].attrs["units"] = "km/s"
-                props["vs"].attrs.update(
-                    {"units": "km/s", "min_value_enforced": min_vs}
-                )
-                props["rho"].attrs["units"] = "g/cm^3"
-        except OSError as e:
-            logger.log(logging.ERROR, f"Failed to create HDF5 file {hdf5_file}: {e}")
-            raise OSError(f"Failed to create HDF5 file {hdf5_file}: {str(e)}")
-
     try:
-        with h5py.File(hdf5_file, "r+") as f:
-            f["mesh/lat"][:, lat_ind] = partial_global_mesh.lat
-            f["mesh/lon"][:, lat_ind] = partial_global_mesh.lon
+        ny = int(vm_params["ny"])
+    except KeyError:
+        logger.log(logging.ERROR, "Missing 'ny' in vm_params.")
+        raise
 
-            # Write property data for this slice to make this Paraview compatible
-            # partial_global_qualities.vp is (nx, nz), need to transpose to (nz, nx) for (z, x)
-            # Dataset is (nz, ny, nx), so [:, lat_ind, :] expects (nz, nx)
-            vp = partial_global_qualities.vp.T
-            vs = vs_data.T
-            rho = partial_global_qualities.rho.T
-            inbasin = partial_global_qualities.inbasin.T
+    # Open/create once; reuse thereafter
+    f, dsets = _ensure_open(out_dir, vm_params, nx, ny, nz, logger)
 
-            expected = (nz, nx)
-            if vp.shape != expected:
-                logger.log(
-                    logging.ERROR,
-                    f"Shape mismatch: vp has shape {vp.shape}, expected {expected}",
-                )
-                raise ValueError(f"Shape mismatch: got {vp.shape}, expected {expected}")
+    # Write mesh lat/lon for this y-slice
+    dsets["lat"][:, lat_ind] = partial_global_mesh.lat
+    dsets["lon"][:, lat_ind] = partial_global_mesh.lon
 
-            f["properties/vp"][:, lat_ind, :] = vp
-            f["properties/vs"][:, lat_ind, :] = vs
-            f["properties/rho"][:, lat_ind, :] = rho
-            f["properties/inbasin"][:, lat_ind, :] = inbasin
+    # (nx, nz) -> (nz, nx) for [:, j, :]
+    vp  = partial_global_qualities.vp.T
+    vs  = vs_data.T
+    rho = partial_global_qualities.rho.T
+    inb = partial_global_qualities.inbasin.T
 
-            f.attrs["last_slice_written"] = lat_ind
-    except OSError as e:
-        logger.log(logging.ERROR, f"Failed to update HDF5 file {hdf5_file}: {e}")
-        raise OSError(f"Failed to update HDF5 file {hdf5_file}: {str(e)}")
-    except Exception as e:
-        if isinstance(e, (SystemExit, KeyboardInterrupt)):
-            raise  # Re-raise critical exceptions
-        logger.log(logging.ERROR, f"Error writing to HDF5 file {hdf5_file}: {e}")
-        raise RuntimeError(f"Error writing to HDF5 file {hdf5_file}: {str(e)}")
+    expected = (nz, nx)
+    if vp.shape != expected:
+        logger.log(logging.ERROR, f"Shape mismatch: got {vp.shape}, expected {expected}")
+        raise ValueError(f"Shape mismatch: got {vp.shape}, expected {expected}")
 
-    # After writing all slices, create the XDMF file
-    if lat_ind == ny - 1:
-        create_xdmf_file(hdf5_file, vm_params, logger)
-        logger.log(logging.INFO, "HDF5 model complete with ParaView compatibility")
+    dsets["vp"][:,  lat_ind, :]  = vp
+    dsets["vs"][:,  lat_ind, :]  = vs
+    dsets["rho"][:, lat_ind, :]  = rho
+    dsets["inbasin"][:, lat_ind, :] = inb
+
+    # Update progress attr (cheap)
+    f.attrs["last_slice_written"] = lat_ind
+
+    # Create XDMF when the last slice *for y* has been written (kept from your version)
+    # NOTE: if slices can arrive out-of-order, consider calling create_xdmf_file(...) after the run.
+    # if lat_ind == ny - 1:
+    #     hdf5_file = Path(out_dir) / "velocity_model.h5"
+    #     create_xdmf_file(hdf5_file, vm_params, logger)
+    #     logger.log(logging.INFO, "HDF5 model complete with ParaView compatibility")

--- a/velocity_modelling/write/hdf5.py
+++ b/velocity_modelling/write/hdf5.py
@@ -23,6 +23,8 @@ import numpy as np
 from velocity_modelling.geometry import PartialGlobalMesh
 from velocity_modelling.velocity3d import PartialGlobalQualities
 
+vm_file_name = "velocity_model.h5"
+
 # ============================================================================
 # XDMF File Creation
 # ============================================================================
@@ -333,7 +335,7 @@ def _ensure_hdf5_file_open(
 
     # Create output directory if it doesn't exist
     out_dir.mkdir(parents=True, exist_ok=True)
-    hdf5_file = out_dir / "velocity_model.h5"
+    hdf5_file = out_dir / vm_file_name
 
     # Configure chunk cache for optimal performance
     rdcc_kwargs = {
@@ -583,7 +585,7 @@ def _hdf5_writer_process(
         if not xdmf_created:
             xdmf_created = True  # Set flag immediately to prevent duplicate execution
             try:
-                hdf5_file = out_dir / "velocity_model.h5"
+                hdf5_file = out_dir / vm_file_name
                 create_xdmf_file(hdf5_file, vm_params, logger)
                 logger.log(
                     logging.INFO, "HDF5 model completed with ParaView compatibility"
@@ -620,7 +622,7 @@ def start_hdf5_writer_process(
     queue : multiprocessing.Queue
         Queue for sending slice data to the writer process
     out_dir_str : str
-        Output directory path as string
+        Output directory path as string (for multiprocessing compatibility)
     vm_params : dict
         Velocity model parameters
     logger : logging.Logger

--- a/velocity_modelling/write/hdf5.py
+++ b/velocity_modelling/write/hdf5.py
@@ -4,9 +4,15 @@ Module for writing velocity model data in HDF5 format.
 This module provides functions to write the velocity model data to HDF5 format files.
 HDF5 (Hierarchical Data Format version 5) is an efficient binary format for storing large
 scientific datasets with metadata.
+
+The module supports both serial and parallel writing modes, with a dedicated writer process
+for parallel processing to ensure thread-safe HDF5 operations.
 """
 import datetime
 import logging
+import multiprocessing as mp
+import os
+import time
 from logging import Logger
 from pathlib import Path
 from typing import Optional
@@ -18,6 +24,10 @@ from velocity_modelling.geometry import PartialGlobalMesh
 from velocity_modelling.velocity3d import PartialGlobalQualities
 
 
+# ============================================================================
+# XDMF File Creation
+# ============================================================================
+
 def create_xdmf_file(hdf5_file: Path, vm_params: dict, logger: logging.Logger) -> None:
     """
     Create an XDMF file to make the HDF5 file compatible with ParaView.
@@ -25,21 +35,27 @@ def create_xdmf_file(hdf5_file: Path, vm_params: dict, logger: logging.Logger) -
     Parameters
     ----------
     hdf5_file : Path
-        Path to the HDF5 file.
+        Path to the HDF5 file
     vm_params : dict
-        Dictionary containing model parameters.
+        Dictionary containing model parameters
     logger : logging.Logger
-        Logger for reporting progress and errors.
+        Logger for reporting progress and errors
+
+    Raises
+    ------
+    KeyError
+        If required parameters (nx, ny, nz) are missing from vm_params
+    RuntimeError
+        If XDMF file creation fails
     """
     xdmf_file = hdf5_file.with_suffix(".xdmf")
     nx = vm_params.get("nx")
     ny = vm_params.get("ny")
     nz = vm_params.get("nz")
+
     if not all([nx, ny, nz]):
-        logger.log(
-            logging.ERROR,
-            "Missing 'nx' 'ny' or 'nz' key in vm_params. Ensure the velocity model parameters are correctly set.",
-        )
+        error_msg = "Missing 'nx' 'ny' or 'nz' key in vm_params. Ensure the velocity model parameters are correctly set."
+        logger.error(error_msg)
         raise KeyError("Missing nx, ny, or nz in vm_params")
 
     hdf5_relative = hdf5_file.name
@@ -88,75 +104,142 @@ def create_xdmf_file(hdf5_file: Path, vm_params: dict, logger: logging.Logger) -
     try:
         with open(xdmf_file, "w") as f:
             f.write(xdmf_content)
-        logger.log(logging.INFO, f"Created ParaView-compatible XDMF file: {xdmf_file}")
+        logger.info(f"Created ParaView-compatible XDMF file: {xdmf_file}")
     except Exception as e:
         if isinstance(e, (SystemExit, KeyboardInterrupt)):
             raise
-        logger.log(logging.ERROR, f"Error creating XDMF file: {e}")
+        logger.error(f"Error creating XDMF file: {e}")
         raise RuntimeError(f"Failed to create XDMF file: {e}")
 
-# --- Cache for one open file per out_dir (single-writer process) ---
+
+# ============================================================================
+# HDF5 File Management and Caching
+# ============================================================================
+
+# Cache for one open file per out_dir (single-writer process)
 _FILE_CACHE = {}  # key: resolved out_dir -> (h5py.File, dict_dsets)
+
+# HDF5 chunk cache configuration for optimal performance
 _RDCC_NBYTES = 128 * 1024 * 1024  # 128MB file-level raw chunk cache
 _RDCC_NSLOTS = 1_000_003          # large prime, reduces hash collisions
-_RDCC_W0     = 0.75               # preemption policy
+_RDCC_W0 = 0.75                   # preemption policy
 
-import time
 
-def _open_file_update_or_create(hdf5_file: Path, rdcc_kwargs):
-    # tiny retry loop for HPC metadata latency
-    for attempt in range(10):
+def _open_file_with_retry(hdf5_file: Path, rdcc_kwargs: dict, max_retries: int = 10) -> h5py.File:
+    """
+    Open HDF5 file with retry logic for HPC metadata latency.
+
+    Parameters
+    ----------
+    hdf5_file : Path
+        Path to the HDF5 file
+    rdcc_kwargs : dict
+        Raw data chunk cache configuration parameters
+    max_retries : int, optional
+        Maximum number of retry attempts (default: 10)
+
+    Returns
+    -------
+    h5py.File
+        Opened HDF5 file handle
+
+    Raises
+    ------
+    OSError
+        If file cannot be opened after all retry attempts
+    """
+    for attempt in range(max_retries):
         mode = "r+" if hdf5_file.exists() else "w"
         try:
             return h5py.File(hdf5_file, mode, libver="latest", **rdcc_kwargs)
         except OSError as e:
             # ENOENT or transient open error → sleep and retry
-            time.sleep(0.05 * (attempt + 1))
-    # final try; raise if still broken
-    return h5py.File(hdf5_file, "r+", libver="latest", **rdcc_kwargs)
+            if attempt < max_retries - 1:
+                time.sleep(0.05 * (attempt + 1))
+            else:
+                # Final attempt - let it raise the exception
+                raise e
 
-def _ensure_open(out_dir: Path, vm_params: dict, nx: int, ny: int, nz: int, logger: Logger):
+
+def _create_hdf5_structure(
+        f: h5py.File,
+        vm_params: dict,
+        nx: int,
+        ny: int,
+        nz: int
+) -> dict:
     """
-    Open/create velocity_model.h5 once and return (f, dsets).
-    dsets: {"vp":ds, "vs":ds, "rho":ds, "inbasin":ds, "lat":ds, "lon":ds}
+    Create the HDF5 file structure with groups and datasets.
+
+    If the file already exists and has the structure, reuse it.
+    Otherwise create new structure.
+
+    Parameters
+    ----------
+    f : h5py.File
+        Open HDF5 file handle
+    vm_params : dict
+        Velocity model parameters
+    nx : int
+        Number of points in x direction
+    ny : int
+        Number of points in y direction
+    nz : int
+        Number of points in z direction
+
+    Returns
+    -------
+    dict
+        Dictionary of created datasets for easy access
     """
-    from pathlib import Path as _P
-    key = str(_P(out_dir).resolve())
-    cached = _FILE_CACHE.get(key)
-    if cached:
-        return cached
+    # Check if structure already exists and has correct dimensions
+    if ("config" in f and "mesh" in f and "properties" in f and
+            "vp" in f["properties"] and f["properties"]["vp"].shape == (nz, ny, nx)):
+        # File structure already exists with correct dimensions, reuse it
+        mesh_group = f["mesh"]
+        props = f["properties"]
 
-    out_dir.mkdir(parents=True, exist_ok=True)
-    hdf5_file = out_dir / "velocity_model.h5"
-
-    # Open once with tuned raw data chunk cache
-    # f = h5py.File(
-    #     hdf5_file, "w", libver="latest",
-    #     rdcc_nbytes=_RDCC_NBYTES, rdcc_nslots=_RDCC_NSLOTS, rdcc_w0=_RDCC_W0
-    # )
-    rdcc_kwargs = dict(rdcc_nbytes=_RDCC_NBYTES, rdcc_nslots=_RDCC_NSLOTS, rdcc_w0=_RDCC_W0)
-    f = _open_file_update_or_create(hdf5_file, rdcc_kwargs)
-
-    # File-level attrs
-    f.attrs.update(
-        {
+        # Update file-level attributes in case they changed
+        f.attrs.update({
             "total_y_slices": ny,
             "format_version": "1.0",
             "creation_date": datetime.datetime.now().isoformat(),
-        }
-    )
+        })
 
-    # Config group (stringify exotic values just like your current code)
+        return {
+            "vp": props["vp"],
+            "vs": props["vs"],
+            "rho": props["rho"],
+            "inbasin": props["inbasin"],
+            "lat": mesh_group["lat"],
+            "lon": mesh_group["lon"]
+        }
+
+    # File doesn't exist or has wrong dimensions - recreate structure
+    # Clear any existing groups first
+    for group_name in ["config", "mesh", "properties"]:
+        if group_name in f:
+            del f[group_name]
+
+    # Set file-level attributes
+    f.attrs.update({
+        "total_y_slices": ny,
+        "format_version": "1.0",
+        "creation_date": datetime.datetime.now().isoformat(),
+    })
+
+    # Create configuration group with stringified parameter values
     config_group = f.create_group("config")
-    config_group.attrs.update(
-        {
-            k: (v.name if hasattr(v, "name") else v.value if hasattr(v, "value") else str(v))
-            for k, v in vm_params.items()
-        }
+    config_group.attrs.update({
+        k: (v.name if hasattr(v, "name") else
+            v.value if hasattr(v, "value") else str(v))
+        for k, v in vm_params.items()
+    })
+    config_group.attrs["config_string"] = "\n".join(
+        f"{k.upper()}={v}" for k, v in vm_params.items()
     )
-    config_group.attrs["config_string"] = "\n".join(f"{k.upper()}={v}" for k, v in vm_params.items())
 
-    # Mesh + properties groups
+    # Create mesh group with coordinate arrays
     mesh_group = f.create_group("mesh")
     mesh_group.create_dataset("x", data=np.arange(nx, dtype=np.int32))
     mesh_group.create_dataset("y", data=np.arange(ny, dtype=np.int32))
@@ -164,220 +247,152 @@ def _ensure_open(out_dir: Path, vm_params: dict, nx: int, ny: int, nz: int, logg
     d_lat = mesh_group.create_dataset("lat", shape=(nx, ny), dtype="f8")
     d_lon = mesh_group.create_dataset("lon", shape=(nx, ny), dtype="f8")
 
+    # Create properties group with optimized chunking
     props = f.create_group("properties")
 
-    # Your layout is (nz, ny, nx) (z, y, x) for ParaView; write whole y-slice fast:
-    shape  = (nz, ny, nx)
-    chunks = (nz, 1,  nx)  # one complete y-slice per chunk  ← key for fast [:, j, :] writes
+    # Use (nz, ny, nx) layout for ParaView compatibility
+    # Chunk by complete y-slices (nz, 1, nx) for fast slice writes
+    shape = (nz, ny, nx)
+    chunks = (nz, 1, nx)  # One complete y-slice per chunk
 
-    d_vp  = props.create_dataset("vp",      shape=shape, dtype="f4", chunks=chunks)
-    d_vs  = props.create_dataset("vs",      shape=shape, dtype="f4", chunks=chunks)
-    d_rho = props.create_dataset("rho",     shape=shape, dtype="f4", chunks=chunks)
+    d_vp = props.create_dataset("vp", shape=shape, dtype="f4", chunks=chunks)
+    d_vs = props.create_dataset("vs", shape=shape, dtype="f4", chunks=chunks)
+    d_rho = props.create_dataset("rho", shape=shape, dtype="f4", chunks=chunks)
     d_inb = props.create_dataset("inbasin", shape=shape, dtype="i1", chunks=chunks)
+
+    # Add dataset attributes
     d_vp.attrs["units"] = "km/s"
-    d_vs.attrs.update({"units": "km/s", "min_value_enforced": vm_params.get("min_vs", 0.0)})
+    d_vs.attrs.update({
+        "units": "km/s",
+        "min_value_enforced": vm_params.get("min_vs", 0.0)
+    })
     d_rho.attrs["units"] = "g/cm^3"
 
-    dsets = {"vp": d_vp, "vs": d_vs, "rho": d_rho, "inbasin": d_inb, "lat": d_lat, "lon": d_lon}
+    return {
+        "vp": d_vp,
+        "vs": d_vs,
+        "rho": d_rho,
+        "inbasin": d_inb,
+        "lat": d_lat,
+        "lon": d_lon
+    }
+
+
+def _ensure_hdf5_file_open(
+        out_dir: Path,
+        vm_params: dict,
+        nx: int,
+        ny: int,
+        nz: int,
+        logger: Optional[Logger] = None
+) -> tuple:
+    """
+    Ensure HDF5 file is open and return file handle and datasets.
+
+    Opens and initializes the HDF5 file once, then caches it for subsequent use.
+    This function is safe to call multiple times - it will reuse existing handles.
+
+    Parameters
+    ----------
+    out_dir : Path
+        Output directory path
+    vm_params : dict
+        Velocity model parameters
+    nx : int
+        Number of points in x direction
+    ny : int
+        Number of points in y direction
+    nz : int
+        Number of points in z direction
+    logger : Logger, optional
+        Logger for debug messages
+
+    Returns
+    -------
+    tuple
+        (h5py.File, dict) - File handle and dataset dictionary
+    """
+    # Use resolved path as cache key to handle symbolic links correctly
+    key = str(Path(out_dir).resolve())
+    cached = _FILE_CACHE.get(key)
+    if cached:
+        return cached
+
+    # Create output directory if it doesn't exist
+    out_dir.mkdir(parents=True, exist_ok=True)
+    hdf5_file = out_dir / "velocity_model.h5"
+
+    # Configure chunk cache for optimal performance
+    rdcc_kwargs = {
+        "rdcc_nbytes": _RDCC_NBYTES,
+        "rdcc_nslots": _RDCC_NSLOTS,
+        "rdcc_w0": _RDCC_W0
+    }
+
+    # Open file with retry logic for HPC environments
+    f = _open_file_with_retry(hdf5_file, rdcc_kwargs)
+
+    # Create HDF5 structure if this is a new file
+    dsets = _create_hdf5_structure(f, vm_params, nx, ny, nz)
+
+    # Cache the file handle and datasets
     _FILE_CACHE[key] = (f, dsets)
 
-    # Close automatically when the process exits
+    # Register cleanup function to close file on process exit
     import atexit
-    def _close_once(k=key):
-        tup = _FILE_CACHE.pop(k, None)
-        if tup:
-            try: tup[0].close()
-            except Exception: pass
-    atexit.register(_close_once)
+    def _cleanup_file(cache_key=key):
+        """Clean up cached file handle on process exit."""
+        cached_data = _FILE_CACHE.pop(cache_key, None)
+        if cached_data:
+            try:
+                cached_data[0].close()
+            except Exception:
+                pass  # Ignore errors during cleanup
+
+    atexit.register(_cleanup_file)
 
     if logger:
-        logger.log(
-            logging.DEBUG,
-            f"[hdf5] opened {hdf5_file} shape={shape} chunks={chunks} rdcc={_RDCC_NBYTES//(1024*1024)}MB",
+        # Define shape and chunks for logging
+        shape = (nz, ny, nx)
+        chunks = (nz, 1, nx)
+        logger.debug(
+            f"[hdf5] Opened {hdf5_file} with shape={shape} chunks={chunks} "
+            f"cache={_RDCC_NBYTES // (1024 * 1024)}MB"
         )
+
     return _FILE_CACHE[key]
 
-def close_cache(out_dir: Optional[Path] = None):
-    """Optional manual close (useful in tests/resets)."""
+
+def close_hdf5_cache(out_dir: Optional[Path] = None) -> None:
+    """
+    Manually close cached HDF5 file handles.
+
+    This function is useful for testing or when you need to ensure files
+    are closed before the process exits.
+
+    Parameters
+    ----------
+    out_dir : Path, optional
+        If specified, close only the file for this directory.
+        If None, close all cached files.
+    """
     if out_dir is None:
         keys = list(_FILE_CACHE.keys())
     else:
         keys = [str(Path(out_dir).resolve())]
-    for k in keys:
-        tup = _FILE_CACHE.pop(k, None)
-        if tup:
-            try: tup[0].close()
-            except Exception: pass
+
+    for key in keys:
+        cached_data = _FILE_CACHE.pop(key, None)
+        if cached_data:
+            try:
+                cached_data[0].close()
+            except Exception:
+                pass  # Ignore errors during cleanup
 
 
-# def write_global_qualities(
-#     out_dir: Path,
-#     partial_global_mesh: PartialGlobalMesh,
-#     partial_global_qualities: PartialGlobalQualities,
-#     lat_ind: int,
-#     vm_params: dict,
-#     logger: Optional[Logger] = None,
-# ) -> None:
-#     """
-#     Write a latitude slice of velocity data to a single consolidated HDF5 file.
-#
-#     For the first slice (lat_ind=0), this creates the file and initializes the structure.
-#     For subsequent slices, it adds data to the existing file.
-#
-#     Parameters
-#     ----------
-#     out_dir : Path
-#         Path to the output directory where the HDF5 file will be written.
-#     partial_global_mesh : PartialGlobalMesh
-#         Mesh data for the current latitude slice.
-#     partial_global_qualities : PartialGlobalQualities
-#         Velocity and density data for the current latitude slice.
-#     lat_ind : int
-#         Latitude index to determine the write mode (write or append).
-#     vm_params : dict
-#         Dictionary containing velocity model parameters from nzcvm.cfg.
-#     logger : Logger, optional
-#         Logger instance for logging messages.
-#
-#     Raises
-#     ------
-#     OSError
-#         If the HDF5 file cannot be written due to permissions or disk issues.
-#     """
-#     if logger is None:
-#         logger = Logger("xdmf")
-#
-#     # Output filename - single file for all slices
-#     hdf5_file = out_dir / "velocity_model.h5"
-#     vs_data = np.copy(partial_global_qualities.vs)
-#     min_vs = vm_params.get("min_vs", 0.0)
-#     vs_data[vs_data < min_vs] = min_vs
-#
-#     # ny is the number of slices in the y direction, but what we are processing here is a single slice
-#     # along y (=lat if not-rotated) axis, so we need to get the total number of slices from the vm_params
-#
-#     try:
-#         ny = vm_params["ny"]
-#     except KeyError:
-#         logger.log(
-#             logging.ERROR,
-#             "Missing 'ny' key in vm_params. Ensure the velocity model parameters are correctly set.",
-#         )
-#         raise KeyError("Missing 'ny' key in vm_params.")
-#
-#     nx, nz = partial_global_qualities.vp.shape
-#
-#     # If first slice, create the file and initialize structure
-#     if lat_ind == 0:
-#         try:
-#             with h5py.File(hdf5_file, "w") as f:
-#                 f.attrs.update(
-#                     {
-#                         "total_y_slices": ny,
-#                         "format_version": "1.0",
-#                         "creation_date": datetime.datetime.now().isoformat(),
-#                     }
-#                 )
-#
-#                 config_group = f.create_group("config")
-#                 config_group.attrs.update(
-#                     {
-#                         k: (
-#                             v.name
-#                             if hasattr(v, "name")
-#                             else v.value
-#                             if hasattr(v, "value")
-#                             else str(v)
-#                         )
-#                         for k, v in vm_params.items()
-#                     }
-#                 )
-#                 config_group.attrs["config_string"] = "\n".join(
-#                     f"{k.upper()}={v}" for k, v in vm_params.items()
-#                 )
-#
-#                 mesh_group = f.create_group("mesh")
-#                 mesh_group.create_dataset("x", data=np.arange(nx, dtype=np.int32))
-#                 mesh_group.create_dataset("y", data=np.arange(ny, dtype=np.int32))
-#                 mesh_group.create_dataset(
-#                     "z", data=np.arange(nz, dtype=np.int32)
-#                 )  # depth 0 is the top, the higher z is the deeper
-#                 mesh_group.create_dataset("lat", shape=(nx, ny), dtype="f8")
-#                 mesh_group.create_dataset("lon", shape=(nx, ny), dtype="f8")
-#
-#                 props = f.create_group("properties")
-#
-#                 # Create datasets with shape (nz, ny, nx): Paraview demands this order
-#                 shape = (nz, ny, nx)
-#
-#                 logger.log(
-#                     logging.DEBUG,
-#                     f"Creating datasets with shape (nz={nz}, ny={ny}, nx={nx})",
-#                 )
-#                 # props.create_dataset("vp", shape=shape, dtype="f4", compression="gzip")
-#                 # props.create_dataset("vs", shape=shape, dtype="f4", compression="gzip")
-#                 # props.create_dataset("rho", shape=shape, dtype="f4", compression="gzip")
-#                 # props.create_dataset(
-#                 #     "inbasin", shape=shape, dtype="i1", compression="gzip"
-#                 # )
-#
-#                 props.create_dataset("vp", shape=shape, dtype="f4")
-#                 props.create_dataset("vs", shape=shape, dtype="f4")
-#                 props.create_dataset("rho", shape=shape, dtype="f4")
-#                 props.create_dataset(
-#                     "inbasin", shape=shape, dtype="i1")
-#
-#                 # Add metadata
-#                 props["vp"].attrs["units"] = "km/s"
-#                 props["vs"].attrs.update(
-#                     {"units": "km/s", "min_value_enforced": min_vs}
-#                 )
-#                 props["rho"].attrs["units"] = "g/cm^3"
-#         except OSError as e:
-#             logger.log(logging.ERROR, f"Failed to create HDF5 file {hdf5_file}: {e}")
-#             raise OSError(f"Failed to create HDF5 file {hdf5_file}: {str(e)}")
-#
-#     try:
-#         with h5py.File(hdf5_file, "r+") as f:
-#             f["mesh/lat"][:, lat_ind] = partial_global_mesh.lat
-#             f["mesh/lon"][:, lat_ind] = partial_global_mesh.lon
-#
-#             # Write property data for this slice to make this Paraview compatible
-#             # partial_global_qualities.vp is (nx, nz), need to transpose to (nz, nx) for (z, x)
-#             # Dataset is (nz, ny, nx), so [:, lat_ind, :] expects (nz, nx)
-#             vp = partial_global_qualities.vp.T
-#             vs = vs_data.T
-#             rho = partial_global_qualities.rho.T
-#             inbasin = partial_global_qualities.inbasin.T
-#
-#             expected = (nz, nx)
-#             if vp.shape != expected:
-#                 logger.log(
-#                     logging.ERROR,
-#                     f"Shape mismatch: vp has shape {vp.shape}, expected {expected}",
-#                 )
-#                 raise ValueError(f"Shape mismatch: got {vp.shape}, expected {expected}")
-#
-#             f["properties/vp"][:, lat_ind, :] = vp
-#             f["properties/vs"][:, lat_ind, :] = vs
-#             f["properties/rho"][:, lat_ind, :] = rho
-#             f["properties/inbasin"][:, lat_ind, :] = inbasin
-#
-#             f.attrs["last_slice_written"] = lat_ind
-#     except OSError as e:
-#         logger.log(logging.ERROR, f"Failed to update HDF5 file {hdf5_file}: {e}")
-#         raise OSError(f"Failed to update HDF5 file {hdf5_file}: {str(e)}")
-#     except Exception as e:
-#         if isinstance(e, (SystemExit, KeyboardInterrupt)):
-#             raise  # Re-raise critical exceptions
-#         logger.log(logging.ERROR, f"Error writing to HDF5 file {hdf5_file}: {e}")
-#         raise RuntimeError(f"Error writing to HDF5 file {hdf5_file}: {str(e)}")
-#
-#     # After writing all slices, create the XDMF file
-#     if lat_ind == ny - 1:
-#         create_xdmf_file(hdf5_file, vm_params, logger)
-#         logger.log(logging.INFO, "HDF5 model complete with ParaView compatibility")
-
+# ============================================================================
+# Core Writing Functions
+# ============================================================================
 
 def write_global_qualities(
     out_dir: Path,
@@ -387,51 +402,210 @@ def write_global_qualities(
     vm_params: dict,
     logger: Optional[Logger] = None,
 ) -> None:
+    """
+    Write a latitude slice of velocity data to the consolidated HDF5 file.
+
+    This function writes velocity model data for a single y-slice to the HDF5 file.
+    It handles both file creation (for the first slice) and subsequent slice updates
+    in an efficient, thread-safe manner.
+
+    Parameters
+    ----------
+    out_dir : Path
+        Output directory where the HDF5 file will be written
+    partial_global_mesh : PartialGlobalMesh
+        Mesh data for the current latitude slice
+    partial_global_qualities : PartialGlobalQualities
+        Velocity and density data for the current latitude slice
+    lat_ind : int
+        Latitude index (y-coordinate) for this slice
+    vm_params : dict
+        Velocity model parameters from configuration
+    logger : Logger, optional
+        Logger instance for progress messages
+
+    Raises
+    ------
+    KeyError
+        If 'ny' parameter is missing from vm_params
+    ValueError
+        If data shapes don't match expected dimensions
+    OSError
+        If HDF5 file operations fail
+    """
     if logger is None:
         logger = logging.getLogger("hdf5")
 
-    # Enforce min_vs before writing
+    # Apply minimum Vs constraint before writing
     vs_data = np.copy(partial_global_qualities.vs)
     min_vs = vm_params.get("min_vs", 0.0)
     vs_data[vs_data < min_vs] = min_vs
 
-    # nx, ny, nz
+    # Extract dimensions
     nx, nz = partial_global_qualities.vp.shape
     try:
         ny = int(vm_params["ny"])
     except KeyError:
-        logger.log(logging.ERROR, "Missing 'ny' in vm_params.")
-        raise
+        logger.error("Missing 'ny' parameter in vm_params")
+        raise KeyError("Missing 'ny' key in vm_params")
 
-    # Open/create once; reuse thereafter
-    f, dsets = _ensure_open(out_dir, vm_params, nx, ny, nz, logger)
+    # Get or create HDF5 file handle and datasets
+    f, dsets = _ensure_hdf5_file_open(out_dir, vm_params, nx, ny, nz, logger)
 
-    # Write mesh lat/lon for this y-slice
+    # Write mesh coordinates for this y-slice
     dsets["lat"][:, lat_ind] = partial_global_mesh.lat
     dsets["lon"][:, lat_ind] = partial_global_mesh.lon
 
-    # (nx, nz) -> (nz, nx) for [:, j, :]
-    vp  = partial_global_qualities.vp.T
-    vs  = vs_data.T
-    rho = partial_global_qualities.rho.T
-    inb = partial_global_qualities.inbasin.T
+    # Transpose data from (nx, nz) to (nz, nx) for HDF5 layout
+    # HDF5 uses (nz, ny, nx) order for ParaView compatibility
+    vp_transposed = partial_global_qualities.vp.T
+    vs_transposed = vs_data.T
+    rho_transposed = partial_global_qualities.rho.T
+    inbasin_transposed = partial_global_qualities.inbasin.T
 
-    expected = (nz, nx)
-    if vp.shape != expected:
-        logger.log(logging.ERROR, f"Shape mismatch: got {vp.shape}, expected {expected}")
-        raise ValueError(f"Shape mismatch: got {vp.shape}, expected {expected}")
+    # Validate data shape
+    expected_shape = (nz, nx)
+    if vp_transposed.shape != expected_shape:
+        error_msg = f"Shape mismatch: got {vp_transposed.shape}, expected {expected_shape}"
+        logger.error(error_msg)
+        raise ValueError(error_msg)
 
-    dsets["vp"][:,  lat_ind, :]  = vp
-    dsets["vs"][:,  lat_ind, :]  = vs
-    dsets["rho"][:, lat_ind, :]  = rho
-    dsets["inbasin"][:, lat_ind, :] = inb
+    # Write property data for this y-slice using optimized slice notation
+    dsets["vp"][:, lat_ind, :] = vp_transposed
+    dsets["vs"][:, lat_ind, :] = vs_transposed
+    dsets["rho"][:, lat_ind, :] = rho_transposed
+    dsets["inbasin"][:, lat_ind, :] = inbasin_transposed
 
-    # Update progress attr (cheap)
+    # Update progress tracking attribute
     f.attrs["last_slice_written"] = lat_ind
 
-    # Create XDMF when the last slice *for y* has been written (kept from your version)
-    # NOTE: if slices can arrive out-of-order, consider calling create_xdmf_file(...) after the run.
-    # if lat_ind == ny - 1:
-    #     hdf5_file = Path(out_dir) / "velocity_model.h5"
-    #     create_xdmf_file(hdf5_file, vm_params, logger)
-    #     logger.log(logging.INFO, "HDF5 model complete with ParaView compatibility")
+    logger.debug(f"Successfully wrote slice {lat_ind} to HDF5 file")
+
+
+# ============================================================================
+# Parallel Processing Support
+# ============================================================================
+
+def _hdf5_writer_process(
+        queue: mp.Queue,
+        out_dir_str: str,
+        vm_params: dict,
+        logger: logging.Logger,
+) -> None:
+    """
+    Dedicated writer process for parallel HDF5 operations.
+
+    This process runs in a separate Python process and handles all HDF5 write
+    operations to ensure thread safety. It receives slice data from worker
+    processes via a queue and writes them to the HDF5 file sequentially.
+
+    Parameters
+    ----------
+    queue : multiprocessing.Queue
+        Queue for receiving slice data from worker processes
+    out_dir_str : str
+        Output directory path as string (for multiprocessing compatibility)
+    vm_params : dict
+        Velocity model parameters
+    logger : logging.Logger
+        Logger instance from the main process
+
+    Notes
+    -----
+    This function runs in a separate process started with 'spawn' context
+    to ensure clean HDF5 library initialization. It processes incoming
+    slice data until it receives a sentinel None value.
+    """
+    import importlib
+    import logging
+    from pathlib import Path
+
+    # Configure HDF5 for multiprocessing safety
+    os.environ.setdefault("HDF5_USE_FILE_LOCKING", "FALSE")
+
+    logger.debug("HDF5 writer process started, waiting for slice data...")
+
+    out_dir = Path(out_dir_str)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    received_slices = 0
+    xdmf_created = False  # Flag to prevent duplicate XDMF creation
+
+    try:
+        # Process incoming slice data until sentinel received
+        while True:
+            item = queue.get()
+            if item is None:  # Sentinel value to stop processing
+                logger.debug(f"Writer process received sentinel, processed {received_slices} slices")
+                break
+
+            if received_slices == 0:
+                logger.debug("Received first slice data")
+
+            # Unpack slice data and write to HDF5
+            j, partial_mesh, partial_qualities = item
+            write_global_qualities(
+                out_dir, partial_mesh, partial_qualities, j, vm_params, logger
+            )
+            received_slices += 1
+
+        # Create ParaView-compatible XDMF file after all slices are written
+        # Only create once to prevent duplicates
+        if not xdmf_created:
+            xdmf_created = True  # Set flag immediately to prevent duplicate execution
+            try:
+                hdf5_file = out_dir / "velocity_model.h5"
+                create_xdmf_file(hdf5_file, vm_params, logger)
+                logger.info("HDF5 model completed with ParaView compatibility")
+                xdmf_created = True
+            except Exception as e:
+                logger.warning(f"Failed to create XDMF file: {e}")
+                xdmf_created = False  # Reset flag if creation failed
+
+    except Exception as e:
+        logger.error(f"HDF5 writer process error: {e}")
+        raise
+    finally:
+        # Clean up cached file handles
+        try:
+            close_hdf5_cache(out_dir)
+        except Exception as e:
+            logger.warning(f"Failed to close HDF5 cache: {e}")
+
+    logger.debug("HDF5 writer process finished")
+
+
+def start_hdf5_writer_process(
+    queue: mp.Queue,
+    out_dir_str: str,
+    vm_params: dict,
+    logger: logging.Logger,
+) -> mp.Process:
+    """
+    Start the dedicated HDF5 writer process for parallel processing.
+
+    Parameters
+    ----------
+    queue : multiprocessing.Queue
+        Queue for sending slice data to the writer process
+    out_dir_str : str
+        Output directory path as string
+    vm_params : dict
+        Velocity model parameters
+    logger : logging.Logger
+        Logger instance from the main process
+
+    Returns
+    -------
+    multiprocessing.Process
+        Started writer process instance
+    """
+    # Use 'spawn' context for clean HDF5 initialization
+    mp_context = mp.get_context("spawn")
+    writer_process = mp_context.Process(
+        target=_hdf5_writer_process,
+        args=(queue, out_dir_str, vm_params, logger),
+        name="HDF5Writer"
+    )
+    writer_process.start()
+    return writer_process

--- a/velocity_modelling/write/hdf5.py
+++ b/velocity_modelling/write/hdf5.py
@@ -96,7 +96,6 @@ def create_xdmf_file(hdf5_file: Path, vm_params: dict, logger: logging.Logger) -
         logger.log(logging.ERROR, f"Error creating XDMF file: {e}")
         raise RuntimeError(f"Failed to create XDMF file: {e}")
 
-
 def write_global_qualities(
     out_dir: Path,
     partial_global_mesh: PartialGlobalMesh,
@@ -201,12 +200,18 @@ def write_global_qualities(
                     logging.DEBUG,
                     f"Creating datasets with shape (nz={nz}, ny={ny}, nx={nx})",
                 )
-                props.create_dataset("vp", shape=shape, dtype="f4", compression="gzip")
-                props.create_dataset("vs", shape=shape, dtype="f4", compression="gzip")
-                props.create_dataset("rho", shape=shape, dtype="f4", compression="gzip")
+                # props.create_dataset("vp", shape=shape, dtype="f4", compression="gzip")
+                # props.create_dataset("vs", shape=shape, dtype="f4", compression="gzip")
+                # props.create_dataset("rho", shape=shape, dtype="f4", compression="gzip")
+                # props.create_dataset(
+                #     "inbasin", shape=shape, dtype="i1", compression="gzip"
+                # )
+
+                props.create_dataset("vp", shape=shape, dtype="f4")
+                props.create_dataset("vs", shape=shape, dtype="f4")
+                props.create_dataset("rho", shape=shape, dtype="f4")
                 props.create_dataset(
-                    "inbasin", shape=shape, dtype="i1", compression="gzip"
-                )
+                    "inbasin", shape=shape, dtype="i1")
 
                 # Add metadata
                 props["vp"].attrs["units"] = "km/s"

--- a/velocity_modelling/write/hdf5.py
+++ b/velocity_modelling/write/hdf5.py
@@ -181,7 +181,7 @@ def _ensure_open(out_dir: Path, vm_params: dict, nx: int, ny: int, nz: int, logg
         )
     return _FILE_CACHE[key]
 
-def _close_cache(out_dir: Optional[Path] = None):
+def close_cache(out_dir: Optional[Path] = None):
     """Optional manual close (useful in tests/resets)."""
     if out_dir is None:
         keys = list(_FILE_CACHE.keys())


### PR DESCRIPTION
# Summary
Added comprehensive parallelization support to generate_3d_model.py with dual-level parallel processing, achieving dramatic performance improvements for Alpine Fault VM generation.

# Key Changes
## New Command Line Arguments

- --`np N`: Number of parallel processes (default: 1 for serial mode)
- `--blas-threads M`: Number of threads for NumPy/BLAS vectorized operations

Total CPU utilization: N × M cores

## Performance Improvements
### Basin Membership Preprocessing (basin_model.py)
- Before: 30 minutes (sequential processing)
- After: <1 minute (embarrassingly parallel implementation, np=64)
Automatically falls back to serial mode when np=1

### Slice-wise Parallel Processing
- Reimplemented the original C code's OpenMP approach for Python
- Addresses file writing challenges with concurrent slice generation + parallel HDF5 write
- Takes ~60 minutes with np=64, blas_threads=2

## File Format Enhancements

- HDF5 format: Now default when np > 1 to support concurrent writing
- Parallel HDF5 support: Custom implementation for thread-safe file operations
- Backward compatibility: emod3d format still supported for serial processing

## New Utility Scripts
- `convert_hdf5_to_emod3d.py`: Format conversion for LF calculations
- `compare_hdf5.py`: File comparison for testing and debugging.

# Validation
- Successfully tested with --np 64 --blas-threads 2 on RCH system (~ 60 minutes total)
- Maintains output compatibility with existing LF calculation pipeline: Verified emod3d output converted from HDF5 and verified against the native emod3d. Identical (1e7 tolerance)

# Usage Examples

## Serial Mode (Backward Compatibility)
```bash
# Original behavior - single process, emod3d format
python generate_3d_model.py [other_args]
# or explicitly
python generate_3d_model.py --np 1 [other_args]
```
## Small-Scale Parallelization
```bash
# 8 cores: 4 processes × 2 BLAS threads each
python generate_3d_model.py --np 4 --blas-threads 2 [other_args]

# 16 cores: 8 processes × 2 BLAS threads each  
python generate_3d_model.py --np 8 --blas-threads 2 [other_args]
```
## Large-Scale Parallelization (Tested Configuration)
```bash
# 128 cores: 64 processes × 2 BLAS threads each (RCH tested)
python generate_3d_model.py --np 64 --blas-threads 2 [other_args]
```
Use this SLURM script if running on RCH 
[alpine_vm.txt](https://github.com/user-attachments/files/22549941/alpine_vm.txt)


## Alternative Configurations
```bash
# CPU-intensive: More processes, fewer BLAS threads
python generate_3d_model.py --np 32 --blas-threads 1 [other_args]

# Memory-intensive: Fewer processes, more BLAS threads  
python generate_3d_model.py --np 16 --blas-threads 4 [other_args]
```
## Format Conversion Workflow
```bash
# Convert to emod3d format for LF calculations
python convert_hdf5_to_emod3d.py input.hdf5 output_dir

# Compare HDF5 files for validation
python compare_hdf5.py file1.hdf5 file2.hdf5
```

# Resource Planning
- Rule of thumb: np × blas_threads = available_cores
- Memory consideration: Higher np increases memory usage
