### PR TITLE
Add velocity model compression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "threadpoolctl>=3.3",
   "tqdm>=4.66",
   "typer>=0.19",
+  "xarray[io]>=2025.10.1",
 ]
 [project.optional-dependencies]
 test = [
@@ -58,6 +59,7 @@ generate_thresholds = "velocity_modelling.scripts.generate_thresholds:app"
 convert_hdf5_to_emod3d = "velocity_modelling.tools.convert_hdf5_to_emod3d:app"
 nzcvm-data-helper = "velocity_modelling.data_helper:app"
 hdf5-to-emod3d = "velocity_modelling.tools.convert_hdf5_to_emod3d:app"
+compress-vm = "velocity_modelling.tools.compress_vm:app"
 # Add more scripts as needed:
 # script_name = "module.path:app"
 

--- a/velocity_modelling/tools/compress_vm.py
+++ b/velocity_modelling/tools/compress_vm.py
@@ -51,8 +51,7 @@ def compress_quality(file: h5py.File, quality: str) -> xr.DataArray:
         and minimum value, respectively.
     """
     quality_array = file["properties"][quality]
-    shape = quality_array.shape
-    (nz, ny, nx) = shape
+    shape = (nz, ny, nx) = quality_array.shape
     quantised_array = np.zeros(shape, dtype=np.uint8)
     int_max = np.iinfo(np.uint8).max
     min, max = get_extrema(quality_array)
@@ -65,8 +64,7 @@ def compress_quality(file: h5py.File, quality: str) -> xr.DataArray:
         np.subtract(y_slice, min, out=y_slice)
         np.divide(y_slice, scale, out=y_slice)
         np.round(y_slice, out=y_slice)
-        y_slice_quantised = y_slice.astype(np.uint8)
-        quantised_array[:, i, :] = y_slice_quantised
+        quantised_array[:, i, :] = y_slice.astype(np.uint8)
 
     attrs = dict(quality_array.attrs)
     attrs["scale_factor"] = scale

--- a/velocity_modelling/tools/compress_vm.py
+++ b/velocity_modelling/tools/compress_vm.py
@@ -1,3 +1,5 @@
+"""Compress velocity models for archival outputs"""
+
 from pathlib import Path
 from typing import Annotated
 

--- a/velocity_modelling/tools/compress_vm.py
+++ b/velocity_modelling/tools/compress_vm.py
@@ -1,0 +1,207 @@
+from pathlib import Path
+from typing import Annotated
+
+import h5py
+import numpy as np
+import typer
+import xarray as xr
+
+app = typer.Typer()
+
+
+def get_extrema(h5_dataset: h5py.Dataset) -> tuple[float, float]:
+    """Get extreme values of hdf5 dataset.
+
+    Parameters
+    ----------
+    h5_dataset : h5py.Dataset
+        HDF5 dataset to find extrema for.
+
+    Returns
+    -------
+    tuple[float, float]
+        (min, max) values for dataset.
+    """
+    min_v, max_v = np.inf, -np.inf
+
+    for i in range(h5_dataset.shape[1]):
+        slice_data = h5_dataset[:, i, :]
+        min_v = min(min_v, np.nanmin(slice_data))
+        max_v = max(max_v, np.nanmax(slice_data))
+    return min_v, max_v
+
+
+def compress_quality(file: h5py.File, quality: str) -> xr.DataArray:
+    """Compress velocity model quality using quantisation method.
+
+    Parameters
+    ----------
+    file : h5py.File
+        File to read quality from.
+    quality : str
+        Quality to read, e.g. rho.
+
+    Returns
+    -------
+    xr.DataArray
+        A quantised dataarray with uint8 values. The scale factor, and
+        add offset attributes record the scale of the quantised array
+        and minimum value, respectively.
+    """
+    quality_array = file["properties"][quality]
+    shape = quality_array.shape
+    (nz, ny, nx) = shape
+    quantised_array = np.zeros(shape, dtype=np.uint8)
+    int_max = np.iinfo(np.uint8).max
+    min, max = get_extrema(quality_array)
+    scale = (max - min) / int_max
+    for i in range(ny):
+        # Copy out one y-slice to a local copy.
+        y_slice = quality_array[:, i, :].astype(np.float32)
+        # y_slice_quantised = round(y_slice / scale_max) as uint8
+        # Need to do this with `out` parameters to avoid extra unneeded copies
+        np.subtract(y_slice, min, out=y_slice)
+        np.divide(y_slice, scale, out=y_slice)
+        np.round(y_slice, out=y_slice)
+        y_slice_quantised = y_slice.astype(np.uint8)
+        quantised_array[:, i, :] = y_slice_quantised
+
+    attrs = dict(quality_array.attrs)
+    attrs["scale_factor"] = scale
+    attrs["add_offset"] = min
+    attrs["_FillValue"] = max
+    z = np.arange(nz)
+    y = np.arange(ny)
+    x = np.arange(nx)
+
+    da = xr.DataArray(
+        quantised_array,
+        dims=("z", "y", "x"),
+        coords=dict(z=z, y=y, x=x),
+        attrs=attrs,
+    )
+    return da
+
+
+def read_inbasin(file: h5py.File) -> xr.DataArray:
+    """Read inbasin vector from velocity model.
+
+    Parameters
+    ----------
+    file : h5py.File
+        Velocity model to read from.
+
+    Returns
+    -------
+    xr.DataArray
+        Data array for inbasin quality.
+    """
+    inbasin = np.array(file["properties"]["inbasin"])
+    (nz, ny, nx) = inbasin.shape
+    z = np.arange(nz)
+    y = np.arange(ny)
+    x = np.arange(nx)
+    attrs = dict(file["properties"]["inbasin"].attrs)
+    da = xr.DataArray(
+        inbasin, dims=("z", "y", "x"), coords=dict(z=z, y=y, x=x), attrs=attrs
+    )
+    return da
+
+
+def compressed_vm_as_dataset(file: h5py.File) -> xr.Dataset:
+    """Convert an HDF5 velocity model into a compressed and quantised xarray dataset.
+
+    Parameters
+    ----------
+    file : h5py.File
+        Velocity model to quantise.
+
+    Returns
+    -------
+    xr.Dataset
+        Compressed and quantised dataset representing the read
+        velocity model.
+    """
+    compressed_vp = compress_quality(file, "vp")
+    compressed_vs = compress_quality(file, "vs")
+    compressed_rho = compress_quality(file, "rho")
+    inbasin = read_inbasin(file)
+    lat = np.array(file["mesh"]["lat"])
+    lon = np.array(file["mesh"]["lon"])
+
+    z_resolution = float(file["config"].attrs["h_depth"])
+    nz = compressed_vp.shape[0]
+    z = np.arange(nz) * z_resolution
+
+    ds = xr.Dataset(
+        {
+            "vp": compressed_vp,
+            "vs": compressed_vs,
+            "rho": compressed_rho,
+            "inbasin": inbasin,
+        },
+    )
+    ds.attrs.update(file["config"].attrs)
+    # Now that the dimensions of the above arrays are consolidated, we can re-use them for the inbasin assignment.
+
+    ds = ds.assign_coords(
+        dict(lon=(("x", "y"), lon), lat=(("x", "y"), lat), depth=(("z"), z)),
+    )
+    ds = ds.set_coords(["lat", "lon", "depth"])
+    return ds
+
+
+@app.command()
+def compress_vm(
+    vm_path: Path,
+    output: Path,
+    complevel: Annotated[int, typer.Option(min=1, max=19)] = 4,
+    chunk_x: Annotated[int | None, typer.Option(min=1)] = 64,
+    chunk_y: Annotated[int | None, typer.Option(min=1)] = 256,
+    chunk_z: Annotated[int | None, typer.Option(min=1)] = 256,
+    shuffle: bool = True,
+) -> None:
+    """Compress a velocity model for archival storage.
+
+    Parameters
+    ----------
+    vm_path : Path
+        Path to velocity model to compress.
+    output : Path
+        Path to store compressed velocity model.
+    complevel : int
+        Compression level for zlib compression.
+    chunk_x : int | None, optional
+        Chunksize in x direction. Set to ``None`` to infer dataset sive.
+    chunk_y : int | None, optional
+        Chunksize in y direction. Set to ``None`` to infer dataset size.
+    chunk_z : int | None, optional
+        Chunksize in z direction. Set to ``None`` to infer dataset size.
+    shuffle : bool
+        If set, enable bit-level shuffling for dataset compression.
+    """
+    with h5py.File(vm_path) as vm:
+        dset = compressed_vm_as_dataset(vm)
+
+    common_options = dict(
+        dtype="uint8",
+        zlib=True,
+        complevel=complevel,
+        shuffle=shuffle,
+        chunksizes=(
+            chunk_x or dset.sizes["x"],
+            chunk_y or dset.sizes["y"],
+            chunk_z or dset.sizes["z"],
+        ),
+    )
+
+    dset.to_netcdf(
+        output,
+        encoding={
+            "vp": common_options,
+            "vs": common_options,
+            "rho": common_options,
+            "inbasin": common_options,
+        },
+        engine="h5netcdf",
+    )

--- a/velocity_modelling/tools/compress_vm.py
+++ b/velocity_modelling/tools/compress_vm.py
@@ -27,7 +27,7 @@ def get_extrema(h5_dataset: h5py.Dataset) -> tuple[float, float]:
         (min, max) values for dataset.
     """
     min_v, max_v = np.inf, -np.inf
-    for chunk in range(h5_dataset.iter_chunks()):
+    for chunk in h5_dataset.iter_chunks():
         slice_data = h5_dataset[chunk]
         min_v = min(min_v, np.nanmin(slice_data))
         max_v = max(max_v, np.nanmax(slice_data))
@@ -71,7 +71,7 @@ def compress_quality(file: h5py.File, quality: str) -> xr.DataArray:
     attrs = dict(quality_array.attrs)
     attrs["scale_factor"] = scale
     attrs["add_offset"] = min
-    attrs["_FillValue"] = max
+    attrs["_FillValue"] = int_max
     z = np.arange(nz)
     y = np.arange(ny)
     x = np.arange(nx)
@@ -157,9 +157,9 @@ def compress_vm(
     vm_path: Path,
     output: Path,
     complevel: Annotated[int, typer.Option(min=1, max=19)] = 4,
-    chunk_x: Annotated[int | None, typer.Option(min=1)] = 64,
+    chunk_x: Annotated[int | None, typer.Option(min=1)] = 256,
     chunk_y: Annotated[int | None, typer.Option(min=1)] = 256,
-    chunk_z: Annotated[int | None, typer.Option(min=1)] = 256,
+    chunk_z: Annotated[int | None, typer.Option(min=1)] = 64,
     shuffle: bool = True,
 ) -> None:
     """Compress a velocity model for archival storage.
@@ -183,16 +183,18 @@ def compress_vm(
     """
     with h5py.File(vm_path) as vm:
         dset = compressed_vm_as_dataset(vm)
-
+    nz = dset.sizes['z']
+    ny = dset.sizes['y']
+    nx = dset.sizes['x']
     common_options = dict(
         dtype="uint8",
         zlib=True,
         complevel=complevel,
         shuffle=shuffle,
         chunksizes=(
-            chunk_z or dset.sizes["z"],
-            chunk_y or dset.sizes["y"],
-            chunk_x or dset.sizes["x"],
+            min(chunk_z or nz, nz),
+            min(chunk_y or ny, ny),
+            min(chunk_x or nx, nx),
         ),
     )
 

--- a/velocity_modelling/tools/compress_vm.py
+++ b/velocity_modelling/tools/compress_vm.py
@@ -1,4 +1,4 @@
-"""Compress velocity models for archival outputs"""
+"""Lossy compress velocity models for archival outputs"""
 
 from pathlib import Path
 from typing import Annotated
@@ -7,6 +7,8 @@ import h5py
 import numpy as np
 import typer
 import xarray as xr
+
+from qcore import cli
 
 app = typer.Typer()
 
@@ -25,9 +27,8 @@ def get_extrema(h5_dataset: h5py.Dataset) -> tuple[float, float]:
         (min, max) values for dataset.
     """
     min_v, max_v = np.inf, -np.inf
-
-    for i in range(h5_dataset.shape[1]):
-        slice_data = h5_dataset[:, i, :]
+    for chunk in range(h5_dataset.iter_chunks()):
+        slice_data = h5_dataset[chunk]
         min_v = min(min_v, np.nanmin(slice_data))
         max_v = max(max_v, np.nanmax(slice_data))
     return min_v, max_v
@@ -57,16 +58,16 @@ def compress_quality(file: h5py.File, quality: str) -> xr.DataArray:
     int_max = np.iinfo(np.uint8).max
     min, max = get_extrema(quality_array)
     scale = (max - min) / int_max
-    for i in range(ny):
+    for chunk in quality_array.iter_chunks():
         # Copy out one y-slice to a local copy.
-        y_slice = quality_array[:, i, :].astype(np.float32)
+        y_slice = quality_array[chunk].astype(np.float32)
         # y_slice_quantised = round(y_slice / scale_max) as uint8
         # Need to do this with `out` parameters to avoid extra unneeded copies
         np.subtract(y_slice, min, out=y_slice)
         np.divide(y_slice, scale, out=y_slice)
         np.round(y_slice, out=y_slice)
         y_slice_quantised = y_slice.astype(np.uint8)
-        quantised_array[:, i, :] = y_slice_quantised
+        quantised_array[chunk] = y_slice_quantised
 
     attrs = dict(quality_array.attrs)
     attrs["scale_factor"] = scale
@@ -149,11 +150,10 @@ def compressed_vm_as_dataset(file: h5py.File) -> xr.Dataset:
     ds = ds.assign_coords(
         dict(lon=(("x", "y"), lon), lat=(("x", "y"), lat), depth=(("z"), z)),
     )
-    ds = ds.set_coords(["lat", "lon", "depth"])
     return ds
 
 
-@app.command()
+@cli.from_docstring(app)
 def compress_vm(
     vm_path: Path,
     output: Path,

--- a/velocity_modelling/tools/compress_vm.py
+++ b/velocity_modelling/tools/compress_vm.py
@@ -191,9 +191,9 @@ def compress_vm(
         complevel=complevel,
         shuffle=shuffle,
         chunksizes=(
-            chunk_x or dset.sizes["x"],
-            chunk_y or dset.sizes["y"],
             chunk_z or dset.sizes["z"],
+            chunk_y or dset.sizes["y"],
+            chunk_x or dset.sizes["x"],
         ),
     )
 


### PR DESCRIPTION
This scripts implements the lessons from the successful xyts compression stage to the velocity model outputs, allowing us to save all velocity models in a compressed format for archival storage in high Rho/Vp/Vs resolution with more than 45x compression ratios possible.

I picked two reasonably small velocity models: a 9gb and 16gb VM and Cesar's Darfield VM (98GB) and compressed them with this code:

VM Size | Compressed Size | Ratio | Vp resolution (km/s) | Vs resolution (km/s) | Rho resolution (g/cm3)
-- | -- | -- | -- | -- | --
9GB | 225M | **45x** | 0.03 | 0.02 | 0.007
16GB | 343M | **48x** | 0.03 | 0.02 | 0.007
98GB | 1.2GB |  **81x** | 0.03 | 0.02 | 0.007

Assuming this ratio scales to the larger models (which does appear to be true of the xyts compression code), we can expect to represent the **full AlpineF2K VM from the Cybershake 100m in less than 3GB** at resolutions similar to above. This resolution of 20-30m/s is more than enough to produce spatial plots and debug VM issues in the case where a result looks bad.

The Vp, Vs, and Rho resolutions are dynamically calculated using two variables:

1. The compression datatype (uint8), which sets the degree of the quanitisation,
2. The range of the Vp, Vs, and Rho for the velocity model (inferred from the VM).

Then the range of the quality divided by 255 is the scale set for the quantisation. By aggressively picking a small datatype for the final model, we further reduce redundant bits in the output. I deemed the extra $\sim 2^8$ factor of resolution not worth at least doubling the size of the compressed velocity model given this is used for exploratory work but I'm open to changing this.

The compressed model is saved as an xarray dataset, which provides compatibility with the rest of the workflow and transparently handles decompression without researchers writing any additional code, i.e.,

``` python
>>> import xarray as xr
>>> import xoak # provides lat/lon indexing using KD-Trees
>>> dset = xr.open_dataset('test_compress_large.h5') # The 16GB model.
>>> dset
<xarray.Dataset> Size: 17GB
Dimensions:  (z: 330, y: 1695, x: 2388)
Coordinates:
  * z        (z) int64 3kB 0 1 2 3 4 5 6 7 8 ... 322 323 324 325 326 327 328 329
  * y        (y) int64 14kB 0 1 2 3 4 5 6 ... 1688 1689 1690 1691 1692 1693 1694
  * x        (x) int64 19kB 0 1 2 3 4 5 6 ... 2381 2382 2383 2384 2385 2386 2387
    lon      (x, y) float64 32MB ...
    lat      (x, y) float64 32MB ...
    depth    (z) float64 3kB ...
Data variables:
    vp       (z, y, x) float32 5GB ... # NOTE: The real value is uint8, and the real size is 100Mb, xarray is transparently representing as float32
    vs       (z, y, x) float32 5GB ...
    rho      (z, y, x) float32 5GB ...
    inbasin  (z, y, x) uint8 1GB ...
Attributes: (12/18)
    call_type:      GENERATE_VELOCITY_MOD
    config_string:  CALL_TYPE=GENERATE_VELOCITY_MOD\nMODEL_VERSION=2.09\nOUTP...
    extent_x:       238.76803023221174
    extent_y:       169.53824916087385
    extent_zmax:    33.0
    extent_zmin:    0.0
    ...             ...
    nz:             330
    origin_lat:     -41.29451828364293
    origin_lon:     174.1625010466834
    origin_rot:     326.6863186192412
    output_dir:     out
    topo_type:      SQUASHED_TAPERED
>>> ds = dset.set_xindex(['lat', 'lon'], xr.indexes.NDPointIndex) # Set an ND-point index for lat and lon to make querying simp\
le
>>> ds.sel(lat=-43.5381, lon=172.6474, method='nearest').vs.values # VS profile at the nearest VM point to CCCC
array([0.69843173, 1.9431396 , 2.2137284 , 2.3039246 , 2.3039246 ,
       2.3219638 , 2.3219638 , 2.340003  , 2.340003  , 2.3580422 ,
       4.2882414 , 4.2882414 , 4.3062806 , 4.3062806 , 4.32432   ,
       ...
       4.32432   , 4.32432   , 4.3423595 , 4.3423595 , 4.3603983 ,
       4.3603983 , 4.3603983 , 4.378438  , 4.378438  , 4.3964767 ],
      dtype=float32)
```

This works without having to decompress explicitly, making it easy for researchers to extract vs profiles from the actual model they simulated with.