### PR TITLE
Consistent coordinates for pre-compute and 1d profile generation

### DIFF
--- a/velocity_modelling/geometry.py
+++ b/velocity_modelling/geometry.py
@@ -224,7 +224,11 @@ class MeshVector:
 
 @njit
 def point_on_vertex(
-    boundary_lats: np.ndarray, boundary_lons: np.ndarray, lat: float, lon: float
+    boundary_lats: np.ndarray,
+    boundary_lons: np.ndarray,
+    lat: float,
+    lon: float,
+    tol: float = 1e-07,
 ) -> bool:
     """
     Check if a point lies on a vertex of a basin boundary.
@@ -239,17 +243,20 @@ def point_on_vertex(
         Latitude of the point to check.
     lon : float
         Longitude of the point to check.
+    tol : float
+        Tolerance for floating point equality test, default: 1e-07
+
 
     Returns
     -------
     bool
-        True if the point matches a boundary vertex within tolerance (1e-07), otherwise False.
+        True if the point matches a boundary vertex within tolerance, otherwise False.
     """
     # Vectorized comparison using NumPy with tolerance
     lat_matches = (
-        np.abs(boundary_lats - lat) <= 1e-07
+        np.abs(boundary_lats - lat) <= tol
     )  # np.isclose is not supported by njit
-    lon_matches = np.abs(boundary_lons - lon) <= 1e-07
+    lon_matches = np.abs(boundary_lons - lon) <= tol
 
     matches = np.logical_and(lat_matches, lon_matches)
 
@@ -335,7 +342,9 @@ def find_edge_inds(
 
 
 @njit
-def find_corner_inds(lats: np.ndarray, lons: np.ndarray, lat: float, lon: float):
+def find_corner_inds(
+    lats: np.ndarray, lons: np.ndarray, lat: float, lon: float, tol: float = 1e-07
+):
     """
     Find the corner indices of the given latitude and longitude arrays.
 
@@ -349,6 +358,8 @@ def find_corner_inds(lats: np.ndarray, lons: np.ndarray, lat: float, lon: float)
         Latitude of the given point.
     lon : float
         Longitude of the given point.
+    tol : float
+        Tolerance for floating point equality test, default : 1e-07
 
     Returns
     -------
@@ -361,18 +372,18 @@ def find_corner_inds(lats: np.ndarray, lons: np.ndarray, lat: float, lon: float)
     nlat = len(lats)
     nlon = len(lons)
 
-    if np.abs(lat - lats[0]) <= 1e-07:
+    if np.abs(lat - lats[0]) <= tol:
         corner_lat_ind = 0
-    elif np.abs(lat - lats[-1]) <= 1e-07:
+    elif np.abs(lat - lats[-1]) <= tol:
         corner_lat_ind = nlat - 1
     else:
         raise ValueError(
             f"Point lies outside of surface bounds. Lat {lat} outside [{lats[0]} {lats[-1]}]"
         )
 
-    if np.abs(lon - lons[0]) <= 1e-07:
+    if np.abs(lon - lons[0]) <= tol:
         corner_lon_ind = 0
-    elif np.abs(lon - lons[-1]) <= 1e-07:
+    elif np.abs(lon - lons[-1]) <= tol:
         corner_lon_ind = nlon - 1
     else:
         raise ValueError(
@@ -384,7 +395,7 @@ def find_corner_inds(lats: np.ndarray, lons: np.ndarray, lat: float, lon: float)
 
 @njit
 def find_basin_adjacent_points_numba(
-    lats: np.ndarray, lons: np.ndarray, lat: float, lon: float
+    lats: np.ndarray, lons: np.ndarray, lat: float, lon: float, tol: float = 1e-07
 ) -> tuple[bool, np.ndarray, np.ndarray]:
     """
     Identify adjacent latitude/longitude indices for a given point in basin coordinates.
@@ -399,6 +410,9 @@ def find_basin_adjacent_points_numba(
         Target latitude for adjacency checks.
     lon : float
         Target longitude for adjacency checks.
+    tol : float
+        Tolerance for floating point equality test, default: 1e-7
+
 
     Returns
     -------
@@ -424,10 +438,11 @@ def find_basin_adjacent_points_numba(
     if 0 < lat_idx < len(lats):
         lat_ind[0] = lat_idx - 1
         lat_ind[1] = lat_idx
-    elif lat_idx == 0 and lats[0] == lat:
+
+    elif lat_idx == 0 and np.abs(lats[0] - lat) <= tol:
         lat_ind[0] = 0
         lat_ind[1] = 1
-    elif lat_idx == len(lats) and lats[-1] == lat:
+    elif lat_idx == len(lats) and np.abs(lats[-1] - lat) <= tol:
         lat_ind[0] = len(lats) - 1
         lat_ind[1] = len(lats)
 
@@ -441,10 +456,10 @@ def find_basin_adjacent_points_numba(
     if 0 < lon_idx < len(lons):
         lon_ind[0] = lon_idx - 1
         lon_ind[1] = lon_idx
-    elif lon_idx == 0 and lons[0] == lon:
+    elif lon_idx == 0 and np.abs(lons[0] - lon) <= tol:
         lon_ind[0] = 0
         lon_ind[1] = 1
-    elif lon_idx == len(lons) and lons[-1] == lon:
+    elif lon_idx == len(lons) and np.abs(lons[-1] - lon) <= tol:
         lon_ind[0] = len(lons) - 1
         lon_ind[1] = len(lons)
 

--- a/velocity_modelling/scripts/generate_1d_profiles.py
+++ b/velocity_modelling/scripts/generate_1d_profiles.py
@@ -602,8 +602,8 @@ def generate_1d_profiles(
             gm.z = np.array([-1000 * dep for dep in depth_values])
 
         global_meshes.append(gm)
-        mesh_lats[i] = np.array(gm.lat).flat[0]
-        mesh_lons[i] = np.array(gm.lon).flat[0]
+        mesh_lats[i] = gm.lat.flat[0]
+        mesh_lons[i] = gm.lon.flat[0]
 
     basin_membership = BasinMembership(
         basin_data_list,

--- a/velocity_modelling/scripts/generate_1d_profiles.py
+++ b/velocity_modelling/scripts/generate_1d_profiles.py
@@ -542,20 +542,25 @@ def generate_1d_profiles(
     # PRE-COMPUTE BASIN MEMBERSHIP FOR ALL PROFILES
     logger.log(logging.INFO, "Pre-computing basin membership for all profiles")
 
-    basin_membership = BasinMembership(
-        basin_data_list,
-        smooth_boundary=nz_tomography_data.smooth_boundary,
-        logger=logger,
-    )
-    profile_basin_membership = basin_membership.check_stations(
-        df["lat"].values, df["lon"].values
-    )
+    # Pre-calculate mesh coordinates to ensure consistency with basin checks.
+    # This prevents "point outside basin" errors caused by slight shifts between
+    # input CSV coordinates and the generated model grid, while maintaining
+    # the speed of vectorized basin checks.
+    mesh_lats = np.zeros(len(df))
+    mesh_lons = np.zeros(len(df))
+    global_meshes = []
 
-    logger.log(logging.INFO, f"Basin membership computed for {len(df)} profiles")
+    # Use a silent logger to avoid spamming logs during coordinate generation
+    silent_logger = logging.getLogger("silent_mesh_gen")
+    silent_logger.setLevel(logging.WARNING)
 
-    for i in tqdm(range(len(df)), desc="Generating profiles", unit="profile"):
-        logger.log(logging.INFO, f"Generating profile {i + 1} of {len(df)}")
+    lats = df["lat"].values
+    lons = df["lon"].values
+    zmins = df["zmin"].values
+    zmaxs = df["zmax"].values
+    spacings = df["spacing"].values
 
+    for i in tqdm(range(len(df)), desc="Pre-computing meshes"):
         # Initialize model extent
         model_extent = {
             "version": vm_params["model_version"],
@@ -563,8 +568,8 @@ def generate_1d_profiles(
             "extent_x": 1.0,
             "extent_y": 1.0,
             "h_lat_lon": 1.0,
-            "origin_lat": df["lat"].iloc[i],
-            "origin_lon": df["lon"].iloc[i],
+            "origin_lat": lats[i],
+            "origin_lon": lons[i],
         }
 
         # Set depth parameters
@@ -574,13 +579,10 @@ def generate_1d_profiles(
             model_extent["h_depth"] = 1.0  # Placeholder, as actual depths are set later
         else:
             spacing_offset = 0.5
-            model_extent["extent_zmin"] = (
-                df["zmin"].iloc[i] - spacing_offset * df["spacing"].iloc[i]
-            )
-            model_extent["extent_zmax"] = (
-                df["zmax"].iloc[i] + spacing_offset * df["spacing"].iloc[i]
-            )
-            model_extent["h_depth"] = df["spacing"].iloc[i]
+            model_extent["extent_zmin"] = zmins[i] - spacing_offset * spacings[i]
+            model_extent["extent_zmax"] = zmaxs[i] + spacing_offset * spacings[i]
+            model_extent["h_depth"] = spacings[i]
+
         model_extent["nx"] = int(
             model_extent["extent_x"] / model_extent["h_lat_lon"] + 0.5
         )
@@ -593,15 +595,34 @@ def generate_1d_profiles(
             + 0.5
         )
 
-        # Generate mesh (only for depth calculation, not basin membership)
-        global_mesh = gen_full_model_grid_great_circle(model_extent, logger)
+        gm = gen_full_model_grid_great_circle(model_extent, silent_logger)
+
         if depth_values:
-            global_mesh.nz = len(depth_values)
+            gm.nz = len(depth_values)
+            gm.z = np.array([-1000 * dep for dep in depth_values])
+
+        global_meshes.append(gm)
+        mesh_lats[i] = np.array(gm.lat).flat[0]
+        mesh_lons[i] = np.array(gm.lon).flat[0]
+
+    basin_membership = BasinMembership(
+        basin_data_list,
+        smooth_boundary=nz_tomography_data.smooth_boundary,
+        logger=logger,
+    )
+    profile_basin_membership = basin_membership.check_stations(mesh_lats, mesh_lons)
+
+    logger.log(logging.INFO, f"Basin membership computed for {len(df)} profiles")
+
+    for i in tqdm(range(len(df)), desc="Generating profiles", unit="profile"):
+        logger.log(logging.INFO, f"Generating profile {i + 1} of {len(df)}")
+
+        global_mesh = global_meshes[i]
+        if depth_values:
             logger.log(
                 logging.DEBUG,
                 f"Number of model points - nx: {global_mesh.nx}, ny: {global_mesh.ny}, nz: {global_mesh.nz}",
             )
-            global_mesh.z = np.array([-1000 * dep for dep in depth_values])
 
         basin_indices = profile_basin_membership[i]
 


### PR DESCRIPTION
This PR fixes a ValueError crash ("Basin point lies outside of the extent of the basin surface") occurring during 1D profile generation for points situated extremely close to basin boundaries.

```
  File "C:\Users\ara299\python_venv\venv_312\Lib\site-packages\velocity_modelling\basin_model.py", line 801, in determine_basin_surface_depths
    adjacent_points = AdjacentPoints.find_basin_adjacent_points(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\ara299\python_venv\venv_312\Lib\site-packages\velocity_modelling\geometry.py", line 782, in find_basin_adjacent_points
    raise ValueError(
ValueError: Basin point lies outside of the extent of the basin surface . 172.72931463769967 -42.99999463769967

```

From inspection, the location that caused this was (172.72932, -43.0)

1. Fix: Coordinate Consistency in generate_1d_profiles.py

The root cause of the crash was a discrepancy between the coordinates used for basin membership checks and those used for velocity interpolation:

- Previously: Basin membership was pre-computed using the raw input coordinates from the CSV file.
- The Issue: When generating the 1D profile, the model grid generation snaps the input coordinates to the nearest grid point (e.g., -43.0 becoming -42.99999...). For edge cases, a point could be technically "inside" the basin based on raw coordinates, but the snapped mesh point would fall slightly "outside" the valid basin grid. This inconsistency caused the interpolation logic to fail when it attempted to query a point it believed was inside the basin.
- The Fix: We now pre-calculate the exact mesh coordinates for all profiles before performing the basin membership check. By using the snapped mesh coordinates for the check, we ensure consistency: if a point snaps outside the basin grid, it is correctly classified as "outside," preventing the crash. This approach retains the performance benefits of vectorized basin checks.


2. Defensive Change: Floating Point Tolerance in geometry.py

Added a tolerance (tol=1e-07) to floating-point comparisons in the geometry logic (specifically find_basin_adjacent_points and related Numba functions).

- Reasoning: Previously, the code relied on strict equality checks or strict inequality for boundary detection.
- Change: Replaced strict checks with tolerance-based comparisons (e.g., abs(a - b) <= tol). While this was not the primary fix for the reported crash, it makes the geometry calculations more robust against minor floating-point inaccuracies inherent in grid generation and projection.