### PR TITLE
Do not offset x and y samples by 0.5 * h_lat_lon

### DIFF
--- a/velocity_modelling/geometry.py
+++ b/velocity_modelling/geometry.py
@@ -1123,9 +1123,9 @@ def gen_full_model_grid_great_circle(
             logging.INFO, f"Number of model points. nx: {nx}, ny: {ny}, nz: {nz}."
         )
 
-    global_mesh.x = 0.5 * h_lat_lon + h_lat_lon * np.arange(nx) - 0.5 * xmax
+    global_mesh.x = h_lat_lon * np.arange(nx) - 0.5 * xmax
 
-    global_mesh.y = 0.5 * h_lat_lon + h_lat_lon * np.arange(ny) - 0.5 * ymax
+    global_mesh.y = h_lat_lon * np.arange(ny) - 0.5 * ymax
     global_mesh.z = -1000.0 * (h_depth * np.arange(nz) + zmin)
     global_mesh.z[0] -= h_depth / 4 * 1000.0
 


### PR DESCRIPTION
Currently the code offsets the x and y samples by h_lat_lon, which contradicts
the way that EMOD3D interprets the lattice generated by the spherical projection
it approximates. This results in the source and sites being offset by a factor
of 0.5 * h_lat_lon (50m in 100m production runs), so that results in slightly
shifted velocity model values from what we expect.


1. The velocity model generates x/y like centre_x - ni / 2 * dx + ni * dx + dx / 2 where ni is the number of points along the x (lon) direction of the model. Ditto for y. The dx/2 offset is why it is cell is centre-registered rather than corner registered. Relevant velocity modelling code: [here](https://github.com/ucgmsim/velocity_modelling/blob/velocity_model_node_correction/velocity_modelling/geometry.py#L1126)
2. In EMOD3D, the function that converts the source location to gridpoints does not exhibit the 0.5 drift. See [source.c](https://github.com/ucgmsim/EMOD3D/blob/master/Emod3d/V3.0.13/source.c#L5714) . It does have code like this: (int)(psrc->xs[isrc] * invh + 0.5) but this is for rounding, not for cell centring. See also [gcproj](https://github.com/ucgmsim/EMOD3D/blob/master/Emod3d/V3.0.13/geoproj_subs.c#L3) which projects into a model with matrices generated from  [gen_matrices](https://github.com/ucgmsim/EMOD3D/blob/master/Emod3d/V3.0.13/geoproj_subs.c#L80) . The integer values of these are not cell-centred offset.